### PR TITLE
Bump start-sdk to 1.5.0 (2.3.9:1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,3 @@
-## How the upstream version is pulled
-- dockerTag in `startos/manifest/index.ts`: `btcpayserver/btcpayserver:<version>`
-- Also has sidecar images: nbxplorer, postgres, shopify — check if those need updating too
+# CLAUDE.md
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the doc map and contribution workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,45 @@
 # Contributing
 
-## Building and Development
+This repo packages [BTCPay Server](https://github.com/btcpayserver/btcpayserver) for StartOS, alongside its bundled NBXplorer UTXO tracker, PostgreSQL sidecar, and Shopify plugin deployer.
 
-See the [StartOS Packaging Guide](https://docs.start9.com/packaging/) for complete environment setup and build instructions.
+## Documentation — keep it in sync
 
-### Quick Start
+- **`README.md`** — what this package is and how it's built (image, volumes, interfaces). For developers and AI assistants.
+- **`instructions.md`** — the user-facing instructions packed into the `.s9pk` and shown on the **Instructions** tab in StartOS, for the person running the service.
+- **`CONTRIBUTING.md`** — this file.
+- **`CLAUDE.md`** — operating rules for AI developers working in this repo.
+
+**Any code change that warrants it must update `README.md` and `instructions.md` in the same change** — a new or renamed action, an added or removed volume / port / interface / dependency, a changed default, a new limitation, any altered user-visible behavior. Don't defer: a package that ships with a stale README or stale instructions is not done, even if the code is perfect. Content rules live in the packaging guide: [Writing READMEs](https://docs.start9.com/packaging/writing-readmes.html) and [Writing Service Instructions](https://docs.start9.com/packaging/writing-instructions.html).
+
+## Building
+
+See the [StartOS Packaging Guide](https://docs.start9.com/packaging/) for environment setup, then:
 
 ```bash
-# Install dependencies
-npm ci
-
-# Build universal package
-make
+npm ci    # install dependencies
+make      # build the universal .s9pk
 ```
 
-## How to Contribute
+## Updating the upstream version
 
-1. Fork the repository and create a branch from `master`
-2. Make your changes
-3. Open a pull request to `master`
+The package pulls **four** upstream images, each pinned as a `dockerTag` under `images` in `startos/manifest/index.ts`. They version independently and can be bumped on their own:
+
+- `btcpay` — `btcpayserver/btcpayserver:<version>` (the main service)
+- `nbx` — `nicolasdorier/nbxplorer:<version>` (UTXO tracker)
+- `postgres` — `btcpayserver/postgres:<version>` (database)
+- `shopify` — `btcpayserver/shopify-app-deployer:<version>` (Shopify plugin runtime)
+
+To bump any of them:
+
+1. Update the matching `dockerTag` in `startos/manifest/index.ts` to the new tag.
+2. Update `version` and `releaseNotes` in the file under `startos/versions/`, renaming it to the new version string. A *new* version file is only needed when the bump carries an `up`/`down` migration, or when you want the old release notes preserved in git history — see [Versions](https://docs.start9.com/packaging/versions.html).
+3. Rebuild (`make`), sideload the `.s9pk`, and confirm it starts and that the **UTXO Tracker Sync** and **Web Interface** health checks recover.
+4. Review `README.md` and `instructions.md` for anything the bump changed.
+
+When bumping BTCPay Server itself, check whether the release notes call for matching NBXplorer or PostgreSQL versions, and bump those tags in the same PR if so.
+
+## How to contribute
+
+1. Fork the repository and create a branch from `master`.
+2. Make your changes — including the doc updates above.
+3. Open a pull request to `master`.

--- a/instructions.md
+++ b/instructions.md
@@ -1,0 +1,52 @@
+# BTCPay Server
+
+## Documentation
+
+- [BTCPay Server documentation](https://docs.btcpayserver.org/) — the upstream operator and merchant guide covering stores, invoices, wallets, plugins, and the Greenfield API.
+
+## What you get on StartOS
+
+- The BTCPay Server **Web UI** interface — the merchant dashboard for stores, invoices, point-of-sale, crowdfund pages, pay buttons, and the Greenfield REST API.
+- A bundled **NBXplorer** UTXO tracker and a bundled **PostgreSQL** database; you do not configure either.
+- Auto-wired connection to **Bitcoin Core** (required) and, on demand, to **LND**, **Core Lightning**, or **Monerod**.
+- Optional **Shopify** integration via the bundled plugin deployer.
+
+## Getting set up
+
+1. Install **Bitcoin Core** first and let it finish its initial block download — BTCPay Server depends on it and NBXplorer cannot index until Bitcoin Core is synced.
+2. Start BTCPay Server. NBXplorer will then sync the UTXO set from Bitcoin Core; the **UTXO Tracker Sync** health check shows progress, and the Web UI will not be fully usable until it reads "Synced".
+3. Open the **Web UI** interface and create your first server admin account. The first account registered through the UI becomes the server administrator.
+4. (Optional) Run **Choose Lightning Node** to wire BTCPay to an internal Lightning node — pick **LND**, **Core Lightning**, or **None/External**. The matching service must be installed; LND or CLN becomes a hard dependency once selected. After your first selection, open BTCPay's **Lightning** settings in the Web UI, choose **Internal Node**, and save — BTCPay requires this one-time confirmation before it will use the wired node for invoices.
+5. (Optional) Run **Enable Altcoins** to turn on Monero. Monerod becomes a required dependency, and BTCPay sets the Monero `block-notify` command on it automatically.
+6. (Optional) Run **Enable Plugins** to turn on the **Shopify** integration if you want to connect a Shopify store.
+
+## Using BTCPay Server
+
+### Web UI
+
+The Web UI is the full BTCPay merchant interface — create stores, generate invoices, manage wallets, configure plugins, and administer users. See the [upstream documentation](https://docs.btcpayserver.org/) for day-to-day operation.
+
+#### Mapping a custom domain to a specific app
+
+You can point a custom domain (e.g. `donate.example.com`, `shop.example.com`) directly at a specific BTCPay app — a crowdfund page, point-of-sale terminal, or pay button — so visitors land on it without navigating the dashboard:
+
+1. Add the domain to the BTCPay **Web UI** interface in the StartOS UI (use Let's Encrypt and create the port-forwarding rules StartOS prompts for).
+2. In the BTCPay Web UI, open **Server Settings** and find **Map specific domains to specific apps**. Enter the domain, pick the app from the dropdown, and save.
+
+### Actions
+
+- **Choose Lightning Node** — pick LND, Core Lightning, or None/External. The selected service becomes a required dependency. After the first selection you must also confirm **Internal Node** under BTCPay's own **Lightning** settings.
+- **Enable Altcoins** — toggle Monero on or off. Turning Monero on makes Monerod a required dependency.
+- **Enable Plugins** — toggle the bundled Shopify integration on or off.
+- **Resync NBXplorer** — re-scan the UTXO set from a chosen block height. Provide the height as an integer; BTCPay restarts and NBXplorer rescans from there.
+- **Reset Server Admin Password** — generate a new random password for the server admin account. Only works when exactly one server admin user exists; copy the password from the result screen before dismissing, it is not retrievable afterwards.
+
+### Backups
+
+StartOS backups include the BTCPay app data, the PostgreSQL `btcpayserver` database (users, stores, invoices), and the package configuration. The NBXplorer index is **not** backed up — on restore, NBXplorer resyncs from Bitcoin Core, which can take time before the Web UI becomes fully usable again.
+
+## Limitations
+
+- **Mainnet only.** Testnet and signet are not exposed by this package.
+- **One internal Lightning node at a time.** You can wire BTCPay to LND *or* CLN, not both simultaneously.
+- **Reset Server Admin Password requires exactly one server admin.** If multiple admin accounts exist, use another admin account to reset the password through the Web UI instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "btcpayserver-startos",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.3",
+        "@start9labs/start-sdk": "1.5.0",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#28.x",
         "cln-startos": "github:Start9Labs/cln-startos#master",
         "lnd-startos": "github:Start9Labs/lnd-startos#master",
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "funding": [
         {
           "type": "github",
@@ -67,9 +67,9 @@
       "license": "MIT"
     },
     "node_modules/@start9labs/start-sdk": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
-      "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.0.tgz",
+      "integrity": "sha512-nsbJdXU2eZS8EFOVH68nOgQvDi/dAN0Swd37od4Luyu+ajKEKTdyt30fze/CbdaXF8gwV54D8A2k3uni1KnLBQ==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -77,12 +77,12 @@
         "@noble/hashes": "^1.8.0",
         "@types/ini": "^4.1.1",
         "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.6.0",
+        "fast-xml-parser": "~5.7.0",
         "ini": "^5.0.0",
         "isomorphic-fetch": "^3.0.0",
         "mime": "^4.1.0",
         "yaml": "^2.8.3",
-        "zod": "^4.3.6",
+        "zod": "4.3.6",
         "zod-deep-partial": "^1.2.0"
       }
     },
@@ -93,9 +93,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
-      "integrity": "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==",
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -126,16 +126,28 @@
     },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#e873695fc4e9fa5a21d13db9b56edbb1dab48d08",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#b3bc91c970db6822b38228b07b646ec7ad3138fa",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.2",
+        "@start9labs/start-sdk": "1.3.3",
         "diskusage": "^1.2.0"
       }
     },
+    "node_modules/bitcoin-core-startos/node_modules/@nodable/entities": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
+      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.2.tgz",
-      "integrity": "sha512-Iw26tSjN+2yKYul8VabrV9VtpbHnEes4FCCxhGrmdFzjP/wc+K4DLqN+cLgqwtVebVB0mJVhhh63nbRil1pqWg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
+      "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -152,19 +164,52 @@
         "zod-deep-partial": "^1.2.0"
       }
     },
-    "node_modules/cln-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#30de0b7eee3339ecb44b469d78b2c9a438d885c9",
+    "node_modules/bitcoin-core-startos/node_modules/fast-xml-parser": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.2",
+        "@nodable/entities": "^1.1.0",
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/cln-startos": {
+      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#f80349c4caa48ac5fdbd618ac46f423d7677cb46",
+      "dependencies": {
+        "@start9labs/start-sdk": "1.3.3",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#28.x",
         "dotenv": "^17.2.0",
         "node-forge": "^1.3.1"
       }
     },
+    "node_modules/cln-startos/node_modules/@nodable/entities": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
+      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/cln-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.2.tgz",
-      "integrity": "sha512-Iw26tSjN+2yKYul8VabrV9VtpbHnEes4FCCxhGrmdFzjP/wc+K4DLqN+cLgqwtVebVB0mJVhhh63nbRil1pqWg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
+      "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -179,6 +224,27 @@
         "yaml": "^2.8.3",
         "zod": "^4.3.6",
         "zod-deep-partial": "^1.2.0"
+      }
+    },
+    "node_modules/cln-startos/node_modules/fast-xml-parser": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^1.1.0",
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/deep-equality-data-structures": {
@@ -220,9 +286,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -231,13 +297,14 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
       "funding": [
         {
           "type": "github",
@@ -246,8 +313,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
         "path-expression-matcher": "^1.5.0",
         "strnum": "^2.2.3"
       },
@@ -275,18 +342,30 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#0a3ab8f4783b04f70bd6f2b735890f5fc850674c",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#95dfbe730758d1fe3e0ef3839f6c7ec598ada032",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.2",
+        "@start9labs/start-sdk": "1.3.3",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#28.x",
         "mime": "^4.0.7",
         "rfc4648": "1.5.4"
       }
     },
+    "node_modules/lnd-startos/node_modules/@nodable/entities": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
+      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/lnd-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.2.tgz",
-      "integrity": "sha512-Iw26tSjN+2yKYul8VabrV9VtpbHnEes4FCCxhGrmdFzjP/wc+K4DLqN+cLgqwtVebVB0mJVhhh63nbRil1pqWg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
+      "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -301,6 +380,27 @@
         "yaml": "^2.8.3",
         "zod": "^4.3.6",
         "zod-deep-partial": "^1.2.0"
+      }
+    },
+    "node_modules/lnd-startos/node_modules/fast-xml-parser": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^1.1.0",
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/mime": {
@@ -319,15 +419,27 @@
       }
     },
     "node_modules/monerod-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/monerod-startos.git#378749633050f863afd023471ce047bd501f7d00",
+      "resolved": "git+ssh://git@github.com/Start9Labs/monerod-startos.git#21136472f6edc932bb2fa7bbeeb8f6b34722f796",
       "dependencies": {
-        "@start9labs/start-sdk": "1.3.2"
+        "@start9labs/start-sdk": "1.3.3"
       }
     },
+    "node_modules/monerod-startos/node_modules/@nodable/entities": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
+      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/monerod-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.2.tgz",
-      "integrity": "sha512-Iw26tSjN+2yKYul8VabrV9VtpbHnEes4FCCxhGrmdFzjP/wc+K4DLqN+cLgqwtVebVB0mJVhhh63nbRil1pqWg==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.3.3.tgz",
+      "integrity": "sha512-aL9ilSj6CyP2+tSooxPZFqWXP1/1dMgYljcu1s2ECoPv6CTmSBqwrBw9SdsQp7PYmnU4rsSZQteWogkDOf93YQ==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -344,10 +456,31 @@
         "zod-deep-partial": "^1.2.0"
       }
     },
+    "node_modules/monerod-startos/node_modules/fast-xml-parser": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
+      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^1.1.0",
+        "fast-xml-builder": "^1.1.4",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/nan": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
+      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -408,7 +541,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -533,9 +665,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -564,9 +696,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -624,6 +756,21 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -634,9 +781,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -653,7 +800,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "check": "tsc --noEmit"
   },
   "dependencies": {
-    "@start9labs/start-sdk": "1.3.3",
+    "@start9labs/start-sdk": "1.5.0",
     "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#28.x",
     "cln-startos": "github:Start9Labs/cln-startos#master",
     "lnd-startos": "github:Start9Labs/lnd-startos#master",

--- a/startos/dependencies.ts
+++ b/startos/dependencies.ts
@@ -41,16 +41,25 @@ export const setDependencies = sdk.setupDependencies(async ({ effects }) => {
       healthChecks: ['monerod'],
     }
 
-    await sdk.action.createTask(effects, 'monerod', autoconfig, 'important', {
-      input: {
-        kind: 'partial',
-        value: {
-          'block-notify': `/usr/bin/curl -so /dev/null "http://btcpayserver.startos:${uiPort}/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s"`,
+    await sdk.action.createTask(
+      effects,
+      'monerod',
+      // monerod-startos pins start-sdk 1.3.3 so its Action type is a distinct
+      // module instance from our 1.5.0 — structurally identical but TS won't
+      // infer GetActionInputType through it. Drop to any until the sibling bumps.
+      autoconfig as any,
+      'important',
+      {
+        input: {
+          kind: 'partial',
+          value: {
+            'block-notify': `/usr/bin/curl -so /dev/null "http://btcpayserver.startos:${uiPort}/monerolikedaemoncallback/block?cryptoCode=xmr&hash=%s"`,
+          },
         },
+        when: { condition: 'input-not-matches', once: false },
+        reason: i18n('BTCPay Server requires a particular block-notify command'),
       },
-      when: { condition: 'input-not-matches', once: false },
-      reason: i18n('BTCPay Server requires a particular block-notify command'),
-    })
+    )
   }
 
   return {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -17,7 +17,6 @@ export const manifest = setupManifest({
   upstreamRepo: 'https://github.com/btcpayserver/btcpayserver',
   marketingUrl: 'https://btcpayserver.org/',
   donationUrl: 'https://btcpayserver.org/donate/',
-  docsUrls: ['https://docs.btcpayserver.org/'],
   description: { short, long },
   volumes: ['main', 'db', 'btcpayserver', 'nbxplorer'],
   images: {

--- a/startos/versions/index.ts
+++ b/startos/versions/index.ts
@@ -1,7 +1,7 @@
 import { VersionGraph } from '@start9labs/start-sdk'
-import { v_2_3_9_0 } from './v2.3.9.0'
+import { v_2_3_9_1 } from './v2.3.9.1'
 
 export const versionGraph = VersionGraph.of({
-  current: v_2_3_9_0,
+  current: v_2_3_9_1,
   other: [],
 })

--- a/startos/versions/v2.3.9.1.ts
+++ b/startos/versions/v2.3.9.1.ts
@@ -123,19 +123,24 @@ async function migrateVolumes(effects: T.Effects) {
   )
 }
 
-export const v_2_3_9_0 = VersionInfo.of({
-  version: '2.3.9:0',
+export const v_2_3_9_1 = VersionInfo.of({
+  version: '2.3.9:1',
   releaseNotes: {
-    en_US:
-      'Update BTCPay Server to 2.3.9, NBXplorer to 2.6.7, postgres sidecar to 18.1-1. 0.3.x → 0.4 migration skips legacy bundled monero wallet data — users with monero altcoin enabled should re-add it via the new monerod dependency and resync.',
-    es_ES:
-      'Actualiza BTCPay Server a 2.3.9, NBXplorer a 2.6.7 y el contenedor postgres a 18.1-1. La migración 0.3.x → 0.4 omite los datos heredados de la cartera monero — los usuarios con la altcoin monero deben volver a añadirla mediante la nueva dependencia monerod y resincronizar.',
-    de_DE:
-      'Aktualisiert BTCPay Server auf 2.3.9, NBXplorer auf 2.6.7 und den Postgres-Sidecar auf 18.1-1. Die Migration 0.3.x → 0.4 überspringt die gebündelten Monero-Wallet-Daten — Nutzer mit aktiviertem Monero-Altcoin müssen ihn über die neue monerod-Abhängigkeit erneut einrichten und neu synchronisieren.',
-    pl_PL:
-      'Aktualizacja BTCPay Server do 2.3.9, NBXplorer do 2.6.7 oraz kontenera postgres do 18.1-1. Migracja 0.3.x → 0.4 pomija starsze dane portfela monero — użytkownicy z włączonym altcoinem monero powinni ponownie skonfigurować go za pomocą nowej zależności monerod i ponownie zsynchronizować.',
-    fr_FR:
-      'Mise à jour de BTCPay Server vers 2.3.9, NBXplorer vers 2.6.7 et du conteneur postgres vers 18.1-1. La migration 0.3.x → 0.4 ignore les données héritées du portefeuille monero — les utilisateurs avec l\'altcoin monero activé doivent l\'ajouter à nouveau via la nouvelle dépendance monerod et resynchroniser.',
+    en_US: `**Internal**
+
+- Bump start-sdk to 1.5.0.`,
+    es_ES: `**Interno**
+
+- Actualiza start-sdk a 1.5.0.`,
+    de_DE: `**Intern**
+
+- Aktualisiert start-sdk auf 1.5.0.`,
+    pl_PL: `**Wewnętrzne**
+
+- Aktualizacja start-sdk do 1.5.0.`,
+    fr_FR: `**Interne**
+
+- Mise à jour de start-sdk vers 1.5.0.`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

- Bumps `@start9labs/start-sdk` 1.3.3 → 1.5.0.
- Drops the removed `docsUrls` manifest field (no longer supported by `SDKManifest` in 1.5.0).
- Refreshes pinned git deps (`bitcoin-core-startos`, `cln-startos`, `lnd-startos`, `monerod-startos`) via `npm update`.
- Bumps StartOS revision from `2.3.9:0` → `2.3.9:1`. Renamed `v2.3.9.0.ts` → `v2.3.9.1.ts` in place (no new migration introduced; the existing 0.3.x → 0.4 migration is preserved).
- Upstream `btcpayserver`, `nicolasdorier/nbxplorer`, `btcpayserver/postgres`, and `btcpayserver/shopify-app-deployer` are all current — nothing to bump.

## Breaking change handled

`sdk.action.createTask(..., autoconfig, ...)` in `startos/dependencies.ts` now fails to typecheck because `monerod-startos` master still pins start-sdk 1.3.3 — its `Action` type is a distinct module instance from our 1.5.0, so the conditional `T extends Action<...>` in `GetActionInputType` falls through to `never`. Worked around with `autoconfig as any`; flagged with a short comment to revert once `monerod-startos` bumps to 1.5.0. Tried `npm overrides` to deduplicate the SDK across siblings — that broke `cln-startos`/`lnd-startos` because their `interfaces.ts` calls `addSsl` without the new required `auth` field, so the localized cast is the minimal fix.

## Test plan

- [x] `npm run check` — clean.
- [x] `make` — both `x86_64` and `aarch64` `.s9pk` artifacts build at `v2.3.9:1`, SDK 1.5.0.