### PR TITLE
chore: bump NBXplorer to 2.6.8; 2.3.9:2 → 2.3.9:3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
       "funding": [
         {
           "type": "github",
@@ -93,9 +93,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -124,18 +124,30 @@
         "ncc": "dist/ncc/cli.js"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bitcoin-core-startos": {
       "name": "bitcoin-core",
-      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#c745e4dffc8a9ff3984bd00c1ea9ea843439b74c",
+      "resolved": "git+ssh://git@github.com/Start9Labs/bitcoin-core-startos.git#cfe246bbb5e9806fb4498b02ec9d542452c25b2d",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.2",
         "diskusage": "^1.2.0"
       }
     },
     "node_modules/bitcoin-core-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
+      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^3.0.0",
@@ -153,32 +165,12 @@
       }
     },
     "node_modules/cln-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#9149541bb06eb6a71addb00939b277e06fe8fb74",
+      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#4727f10729e4db1c07bb131a19e81a38cedfb95a",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.3",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "dotenv": "^17.2.0",
         "node-forge": "^1.3.1"
-      }
-    },
-    "node_modules/cln-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "@types/ini": "^4.1.1",
-        "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.7.0",
-        "ini": "^5.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "4.3.6",
-        "zod-deep-partial": "^1.2.0"
       }
     },
     "node_modules/deep-equality-data-structures": {
@@ -276,32 +268,12 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#0e166a059e2b1768abb6747b34780d52c160ad26",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#486cfd64894213a9fba7ae5fd91a6152cf965470",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.1",
+        "@start9labs/start-sdk": "1.5.3",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "mime": "^4.0.7",
         "rfc4648": "1.5.4"
-      }
-    },
-    "node_modules/lnd-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.1.tgz",
-      "integrity": "sha512-iztLiOCtHuTfUCd2JOWio4OvBk5qFGa0NI+G+ZB/dQ1sWtunYEnzqMcF6N/Ss4L6+7bBOMAMU4VuhyxeZoHyIw==",
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "@types/ini": "^4.1.1",
-        "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.7.0",
-        "ini": "^5.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "4.3.6",
-        "zod-deep-partial": "^1.2.0"
       }
     },
     "node_modules/mime": {
@@ -320,7 +292,7 @@
       }
     },
     "node_modules/monerod-startos": {
-      "resolved": "git+ssh://git@github.com/Start9-Community/monerod-startos.git#b9b8e98aab2e395581010feed7be93ad123cace5",
+      "resolved": "git+ssh://git@github.com/Start9-Community/monerod-startos.git#87d8bbeee61e2cef8bc456b425cd241a38ee1740",
       "dependencies": {
         "@start9labs/start-sdk": "1.5.2"
       }
@@ -405,15 +377,14 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
-      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
+      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "pg-connection-string": "^2.12.0",
-        "pg-pool": "^3.13.0",
-        "pg-protocol": "^1.13.0",
+        "pg-connection-string": "^2.13.0",
+        "pg-pool": "^3.14.0",
+        "pg-protocol": "^1.14.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -421,7 +392,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.3.0"
+        "pg-cloudflare": "^1.4.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -433,16 +404,16 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
-      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
+      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
-      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
+      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -455,18 +426,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
-      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+      "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -534,9 +505,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -565,16 +536,19 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -669,7 +643,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,9 +55,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
-      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
       "funding": [
         {
           "type": "github",
@@ -93,9 +93,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.20",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
-      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -125,9 +125,9 @@
       }
     },
     "node_modules/anynum": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
-      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
       "funding": [
         {
           "type": "github",
@@ -165,7 +165,7 @@
       }
     },
     "node_modules/cln-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#4727f10729e4db1c07bb131a19e81a38cedfb95a",
+      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#73558f69d4a132ec10b0a2cf4d8789fb03ef4cab",
       "dependencies": {
         "@start9labs/start-sdk": "1.5.3",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
@@ -268,7 +268,7 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#486cfd64894213a9fba7ae5fd91a6152cf965470",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#9a682c60d659b077629612ca4d6d0373a22918b6",
       "dependencies": {
         "@start9labs/start-sdk": "1.5.3",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
@@ -292,35 +292,15 @@
       }
     },
     "node_modules/monerod-startos": {
-      "resolved": "git+ssh://git@github.com/Start9-Community/monerod-startos.git#87d8bbeee61e2cef8bc456b425cd241a38ee1740",
+      "resolved": "git+ssh://git@github.com/Start9-Community/monerod-startos.git#d40e825d6377c9fdce96bbcb7b90e49b779a42df",
       "dependencies": {
-        "@start9labs/start-sdk": "1.5.2"
-      }
-    },
-    "node_modules/monerod-startos/node_modules/@start9labs/start-sdk": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/@start9labs/start-sdk/-/start-sdk-1.5.2.tgz",
-      "integrity": "sha512-3L4OKuH9kUtuH6G20BSPk85yN/jS3+0WNkP19ahwO9Nc7L6STel4hujvKii3osf0p0tU2q5Mk2Y8b9f2dVR1ng==",
-      "license": "MIT",
-      "dependencies": {
-        "@iarna/toml": "^3.0.0",
-        "@noble/curves": "^1.9.7",
-        "@noble/hashes": "^1.8.0",
-        "@types/ini": "^4.1.1",
-        "deep-equality-data-structures": "^2.0.0",
-        "fast-xml-parser": "~5.7.0",
-        "ini": "^5.0.0",
-        "isomorphic-fetch": "^3.0.0",
-        "mime": "^4.1.0",
-        "yaml": "^2.8.3",
-        "zod": "4.3.6",
-        "zod-deep-partial": "^1.2.0"
+        "@start9labs/start-sdk": "1.5.3"
       }
     },
     "node_modules/nan": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.27.0.tgz",
-      "integrity": "sha512-hC+0LidcL3XE4rp1C4H54KujgXKzbfyTngZTwBByQxsOxCEKZT0MPQ4hOKUH2jU1OYstqdDH4onyHPDzcV0XdQ==",
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
       "license": "MIT"
     },
     "node_modules/node-fetch": {
@@ -362,9 +342,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
       "funding": [
         {
           "type": "github",
@@ -377,14 +357,14 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
-      "integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
+      "version": "8.22.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.22.0.tgz",
+      "integrity": "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==",
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.13.0",
+        "pg-connection-string": "^2.14.0",
         "pg-pool": "^3.14.0",
-        "pg-protocol": "^1.14.0",
+        "pg-protocol": "^1.15.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -411,9 +391,9 @@
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
-      "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+      "integrity": "sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==",
       "license": "MIT"
     },
     "node_modules/pg-int8": {
@@ -435,9 +415,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
-      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -536,9 +516,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
-      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
       "funding": [
         {
           "type": "github",
@@ -547,7 +527,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "anynum": "^1.0.0"
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/tr46": {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -22,7 +22,7 @@ export const manifest = setupManifest({
   images: {
     btcpay: {
       source: {
-        dockerTag: 'btcpayserver/btcpayserver:2.3.9',
+        dockerTag: 'btcpayserver/btcpayserver:2.4.0',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -28,7 +28,7 @@ export const manifest = setupManifest({
     },
     nbx: {
       source: {
-        dockerTag: 'nicolasdorier/nbxplorer:2.6.7',
+        dockerTag: 'nicolasdorier/nbxplorer:2.6.8',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -124,13 +124,18 @@ async function migrateVolumes(effects: T.Effects) {
 }
 
 export const current = VersionInfo.of({
-  version: '2.3.9:2',
+  version: '2.3.9:3',
   releaseNotes: {
-    en_US: 'Fixes a bug that caused database backups to be empty.',
-    es_ES: 'Corrige un error que provocaba que las copias de seguridad de la base de datos estuvieran vacías.',
-    de_DE: 'Behebt einen Fehler, durch den Datenbank-Backups leer waren.',
-    pl_PL: 'Naprawia błąd powodujący, że kopie zapasowe bazy danych były puste.',
-    fr_FR: 'Corrige un bug qui rendait les sauvegardes de base de données vides.',
+    en_US:
+      'Updated NBXplorer to 2.6.8 (dependency bumps and internal improvements). See https://github.com/btcpayserver/NBXplorer/compare/v2.6.7...v2.6.8',
+    es_ES:
+      'Se actualizó NBXplorer a 2.6.8 (actualizaciones de dependencias y mejoras internas). Consulta https://github.com/btcpayserver/NBXplorer/compare/v2.6.7...v2.6.8',
+    de_DE:
+      'NBXplorer auf 2.6.8 aktualisiert (Abhängigkeits-Updates und interne Verbesserungen). Siehe https://github.com/btcpayserver/NBXplorer/compare/v2.6.7...v2.6.8',
+    pl_PL:
+      'Zaktualizowano NBXplorer do 2.6.8 (aktualizacje zależności i wewnętrzne usprawnienia). Zobacz https://github.com/btcpayserver/NBXplorer/compare/v2.6.7...v2.6.8',
+    fr_FR:
+      'Mise à jour de NBXplorer vers 2.6.8 (mises à jour des dépendances et améliorations internes). Voir https://github.com/btcpayserver/NBXplorer/compare/v2.6.7...v2.6.8',
   },
   migrations: {
     up: async ({ effects }) => {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -124,18 +124,38 @@ async function migrateVolumes(effects: T.Effects) {
 }
 
 export const current = VersionInfo.of({
-  version: '2.3.9:3',
+  version: '2.4.0:0',
   releaseNotes: {
-    en_US:
-      'Updated NBXplorer to 2.6.8 (dependency bumps and internal improvements). See https://github.com/btcpayserver/NBXplorer/compare/v2.6.7...v2.6.8',
-    es_ES:
-      'Se actualizó NBXplorer a 2.6.8 (actualizaciones de dependencias y mejoras internas). Consulta https://github.com/btcpayserver/NBXplorer/compare/v2.6.7...v2.6.8',
-    de_DE:
-      'NBXplorer auf 2.6.8 aktualisiert (Abhängigkeits-Updates und interne Verbesserungen). Siehe https://github.com/btcpayserver/NBXplorer/compare/v2.6.7...v2.6.8',
-    pl_PL:
-      'Zaktualizowano NBXplorer do 2.6.8 (aktualizacje zależności i wewnętrzne usprawnienia). Zobacz https://github.com/btcpayserver/NBXplorer/compare/v2.6.7...v2.6.8',
-    fr_FR:
-      'Mise à jour de NBXplorer vers 2.6.8 (mises à jour des dépendances et améliorations internes). Voir https://github.com/btcpayserver/NBXplorer/compare/v2.6.7...v2.6.8',
+    en_US: `Updated BTCPay Server to 2.4.0.
+
+- New features: multisig wallet setup, global search bar, passkey (loginless/passwordless) authentication, more granular wallet permissions, and wallet transaction search with date filters.
+- Breaking changes: the LNBank, Lightning Charge, and LNDHub Lightning backends are no longer supported; Boltcards and Shopify v2 plugin users must upgrade those plugins.
+
+See https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.0`,
+    es_ES: `Se actualizó BTCPay Server a 2.4.0.
+
+- Nuevas funciones: configuración de monedero multifirma, barra de búsqueda global, autenticación con passkey (sin inicio de sesión ni contraseña), permisos de monedero más granulares y búsqueda de transacciones del monedero con filtros de fecha.
+- Cambios importantes: los backends de Lightning LNBank, Lightning Charge y LNDHub ya no son compatibles; los usuarios de los complementos Boltcards y Shopify v2 deben actualizarlos.
+
+Consulta https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.0`,
+    de_DE: `BTCPay Server auf 2.4.0 aktualisiert.
+
+- Neue Funktionen: Einrichtung von Multisig-Wallets, globale Suchleiste, Passkey-Authentifizierung (ohne Login/Passwort), feingranularere Wallet-Berechtigungen sowie Wallet-Transaktionssuche mit Datumsfiltern.
+- Breaking Changes: Die Lightning-Backends LNBank, Lightning Charge und LNDHub werden nicht mehr unterstützt; Nutzer der Boltcards- und Shopify-v2-Plugins müssen diese aktualisieren.
+
+Siehe https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.0`,
+    pl_PL: `Zaktualizowano BTCPay Server do 2.4.0.
+
+- Nowe funkcje: konfiguracja portfela multisig, globalny pasek wyszukiwania, uwierzytelnianie passkey (bez logowania i hasła), bardziej szczegółowe uprawnienia portfela oraz wyszukiwanie transakcji portfela z filtrami dat.
+- Zmiany powodujące niezgodność: backendy Lightning LNBank, Lightning Charge i LNDHub nie są już obsługiwane; użytkownicy wtyczek Boltcards i Shopify v2 muszą je zaktualizować.
+
+Zobacz https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.0`,
+    fr_FR: `Mise à jour de BTCPay Server vers 2.4.0.
+
+- Nouvelles fonctionnalités : configuration de portefeuille multisig, barre de recherche globale, authentification par passkey (sans connexion ni mot de passe), permissions de portefeuille plus granulaires et recherche de transactions du portefeuille avec filtres de date.
+- Changements incompatibles : les backends Lightning LNBank, Lightning Charge et LNDHub ne sont plus pris en charge ; les utilisateurs des plugins Boltcards et Shopify v2 doivent les mettre à jour.
+
+Voir https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.0`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Bumps the bundled **NBXplorer** UTXO tracker from `2.6.7` to `2.6.8`. The primary upstream (BTCPay Server `2.3.9`), Postgres (`18.1-1`) and the Shopify deployer (`1.8`) are unchanged, so the StartOS revision increments: `2.3.9:2 → 2.3.9:3`.

### Upstream changes (NBXplorer 2.6.7 → 2.6.8)

- Adds `curl` to the Docker image to support health checks.
- Dependency bumps and faster tests (internal).
- Full diff: https://github.com/btcpayserver/NBXplorer/compare/v2.6.7...v2.6.8

### Other

- `npm update` refreshed `package-lock.json` (no `@start9labs/start-sdk` change — already at latest `1.5.3`).
- No new migration; the existing volume migration stays on the current version node (`other: []`).
- README / instructions reference NBXplorer by image name and behavior only (no version strings), so no doc changes were needed.

## Test plan

- `npm run check` (tsc) passes clean for `2.3.9:3`.
- `make` / s9pk build verification happens in PR review.