### PR TITLE
chore: bump PostgreSQL to 18.4; 2.4.0:0 → 2.4.0:1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -165,7 +165,7 @@
       }
     },
     "node_modules/cln-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#73558f69d4a132ec10b0a2cf4d8789fb03ef4cab",
+      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#e30675069736a47fc12b2e0d533cc1763b03a5d5",
       "dependencies": {
         "@start9labs/start-sdk": "1.5.3",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
@@ -268,7 +268,7 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#9a682c60d659b077629612ca4d6d0373a22918b6",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#411e552648e8414e97ffbfd02fd986169a5f57e5",
       "dependencies": {
         "@start9labs/start-sdk": "1.5.3",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
@@ -485,9 +485,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
-      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "version": "3.9.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
+      "integrity": "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -34,7 +34,7 @@ export const manifest = setupManifest({
     },
     postgres: {
       source: {
-        dockerTag: 'btcpayserver/postgres:18.1-1',
+        dockerTag: 'btcpayserver/postgres:18.4',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -124,38 +124,23 @@ async function migrateVolumes(effects: T.Effects) {
 }
 
 export const current = VersionInfo.of({
-  version: '2.4.0:0',
+  version: '2.4.0:1',
   releaseNotes: {
-    en_US: `Updated BTCPay Server to 2.4.0.
+    en_US: `Updated the bundled PostgreSQL image to 18.4, matching BTCPay Server's upstream stack. This is a PostgreSQL 18 minor release with bug and security fixes; no action is required and existing data is upgraded automatically.
 
-- New features: multisig wallet setup, global search bar, passkey (loginless/passwordless) authentication, more granular wallet permissions, and wallet transaction search with date filters.
-- Breaking changes: the LNBank, Lightning Charge, and LNDHub Lightning backends are no longer supported; Boltcards and Shopify v2 plugin users must upgrade those plugins.
+See https://www.postgresql.org/docs/release/`,
+    es_ES: `Se actualizó la imagen de PostgreSQL incluida a 18.4, igualando la pila oficial de BTCPay Server. Es una versión menor de PostgreSQL 18 con correcciones de errores y de seguridad; no se requiere ninguna acción y los datos existentes se actualizan automáticamente.
 
-See https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.0`,
-    es_ES: `Se actualizó BTCPay Server a 2.4.0.
+Consulta https://www.postgresql.org/docs/release/`,
+    de_DE: `Das mitgelieferte PostgreSQL-Image wurde auf 18.4 aktualisiert, passend zum Upstream-Stack von BTCPay Server. Dies ist eine PostgreSQL-18-Minor-Version mit Fehler- und Sicherheitskorrekturen; es ist keine Aktion erforderlich und vorhandene Daten werden automatisch aktualisiert.
 
-- Nuevas funciones: configuración de monedero multifirma, barra de búsqueda global, autenticación con passkey (sin inicio de sesión ni contraseña), permisos de monedero más granulares y búsqueda de transacciones del monedero con filtros de fecha.
-- Cambios importantes: los backends de Lightning LNBank, Lightning Charge y LNDHub ya no son compatibles; los usuarios de los complementos Boltcards y Shopify v2 deben actualizarlos.
+Siehe https://www.postgresql.org/docs/release/`,
+    pl_PL: `Zaktualizowano dołączony obraz PostgreSQL do 18.4, zgodnie ze stosem upstream BTCPay Server. To wydanie pomocnicze PostgreSQL 18 z poprawkami błędów i zabezpieczeń; nie jest wymagane żadne działanie, a istniejące dane są aktualizowane automatycznie.
 
-Consulta https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.0`,
-    de_DE: `BTCPay Server auf 2.4.0 aktualisiert.
+Zobacz https://www.postgresql.org/docs/release/`,
+    fr_FR: `Mise à jour de l'image PostgreSQL fournie vers 18.4, en cohérence avec la pile upstream de BTCPay Server. Il s'agit d'une version mineure de PostgreSQL 18 avec des corrections de bogues et de sécurité ; aucune action n'est requise et les données existantes sont mises à jour automatiquement.
 
-- Neue Funktionen: Einrichtung von Multisig-Wallets, globale Suchleiste, Passkey-Authentifizierung (ohne Login/Passwort), feingranularere Wallet-Berechtigungen sowie Wallet-Transaktionssuche mit Datumsfiltern.
-- Breaking Changes: Die Lightning-Backends LNBank, Lightning Charge und LNDHub werden nicht mehr unterstützt; Nutzer der Boltcards- und Shopify-v2-Plugins müssen diese aktualisieren.
-
-Siehe https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.0`,
-    pl_PL: `Zaktualizowano BTCPay Server do 2.4.0.
-
-- Nowe funkcje: konfiguracja portfela multisig, globalny pasek wyszukiwania, uwierzytelnianie passkey (bez logowania i hasła), bardziej szczegółowe uprawnienia portfela oraz wyszukiwanie transakcji portfela z filtrami dat.
-- Zmiany powodujące niezgodność: backendy Lightning LNBank, Lightning Charge i LNDHub nie są już obsługiwane; użytkownicy wtyczek Boltcards i Shopify v2 muszą je zaktualizować.
-
-Zobacz https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.0`,
-    fr_FR: `Mise à jour de BTCPay Server vers 2.4.0.
-
-- Nouvelles fonctionnalités : configuration de portefeuille multisig, barre de recherche globale, authentification par passkey (sans connexion ni mot de passe), permissions de portefeuille plus granulaires et recherche de transactions du portefeuille avec filtres de date.
-- Changements incompatibles : les backends Lightning LNBank, Lightning Charge et LNDHub ne sont plus pris en charge ; les utilisateurs des plugins Boltcards et Shopify v2 doivent les mettre à jour.
-
-Voir https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.0`,
+Voir https://www.postgresql.org/docs/release/`,
   },
   migrations: {
     up: async ({ effects }) => {


### PR DESCRIPTION
## Summary

Monitor-cycle bump of the bundled **PostgreSQL** image, which moved independently of BTCPay Server.

- `images.postgres.source.dockerTag`: `btcpayserver/postgres:18.1-1` → `btcpayserver/postgres:18.4`, matching the version BTCPay Server's own `btcpayserver-docker` stack now ships (`docker-compose-generator/docker-fragments/postgres.yml` → `image: btcpayserver/postgres:18.4`).
- StartOS version `2.4.0:0` → `2.4.0:1` (BTCPay Server itself is unchanged at 2.4.0, so the base version holds and the revision increments).

The other three images are already current: BTCPay Server `2.4.0`, NBXplorer `2.6.8`, Shopify app deployer `1.8`.

`@start9labs/start-sdk` is already at the latest published version (`1.5.3`); `npm update` refreshed the lockfile only.

## Migration notes

`18.1` → `18.4` is a PostgreSQL **18 minor** release (same on-disk format) — no `pg_upgrade` and no data migration required. The existing PG13→PG18 upgrade migration carried on the current node is unaffected (it now targets the 18.4 image). No new `up`/`down` migration added, so `current.ts` was edited in place.

## Test plan

- [x] `npm run check` (tsc typecheck) passes for StartOS version `2.4.0:1`.