### PR TITLE
chore: bump BTCPay Server to 2.4.1; NBXplorer 2.6.9, Shopify deployer 1.9; 2.4.0:4 → 2.4.1:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -22,13 +22,13 @@ export const manifest = setupManifest({
   images: {
     btcpay: {
       source: {
-        dockerTag: 'btcpayserver/btcpayserver:2.4.0',
+        dockerTag: 'btcpayserver/btcpayserver:2.4.1',
       },
       arch: ['x86_64', 'aarch64'],
     },
     nbx: {
       source: {
-        dockerTag: 'nicolasdorier/nbxplorer:2.6.8',
+        dockerTag: 'nicolasdorier/nbxplorer:2.6.9',
       },
       arch: ['x86_64', 'aarch64'],
     },
@@ -40,7 +40,7 @@ export const manifest = setupManifest({
     },
     shopify: {
       source: {
-        dockerTag: 'btcpayserver/shopify-app-deployer:1.8',
+        dockerTag: 'btcpayserver/shopify-app-deployer:1.9',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,13 +1,53 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '2.4.0:4',
+  version: '2.4.1:0',
   releaseNotes: {
-    en_US: 'Internal updates',
-    es_ES: 'Actualizaciones internas',
-    de_DE: 'Interne Aktualisierungen',
-    pl_PL: 'Aktualizacje wewnętrzne',
-    fr_FR: 'Mises à jour internes',
+    en_US: `Updated BTCPay Server to 2.4.1, NBXplorer to 2.6.9, and the Shopify app deployer to 1.9.
+
+**BTCPay Server 2.4.1**
+
+- Right-to-left (RTL) language support (Arabic, Hebrew, Persian)
+- BIP-329 wallet label import and editable invoice comments
+- Fixes for Boltcard payments and Core Lightning compatibility; LNDHub is now enabled by default
+
+NBXplorer and the Shopify deployer receive minor maintenance updates. Full release notes: https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.1`,
+    es_ES: `Se actualizó BTCPay Server a 2.4.1, NBXplorer a 2.6.9 y el desplegador de la app de Shopify a 1.9.
+
+**BTCPay Server 2.4.1**
+
+- Compatibilidad con idiomas de derecha a izquierda (RTL) (árabe, hebreo, persa)
+- Importación de etiquetas de monedero BIP-329 y comentarios de factura editables
+- Correcciones para pagos con Boltcard y compatibilidad con Core Lightning; LNDHub ahora está habilitado de forma predeterminada
+
+NBXplorer y el desplegador de Shopify reciben actualizaciones de mantenimiento menores. Notas de la versión completas: https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.1`,
+    de_DE: `BTCPay Server auf 2.4.1, NBXplorer auf 2.6.9 und den Shopify-App-Deployer auf 1.9 aktualisiert.
+
+**BTCPay Server 2.4.1**
+
+- Unterstützung für Rechts-nach-links-Sprachen (RTL) (Arabisch, Hebräisch, Persisch)
+- BIP-329-Wallet-Label-Import und bearbeitbare Rechnungskommentare
+- Korrekturen für Boltcard-Zahlungen und Core-Lightning-Kompatibilität; LNDHub ist jetzt standardmäßig aktiviert
+
+NBXplorer und der Shopify-Deployer erhalten kleinere Wartungsupdates. Vollständige Versionshinweise: https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.1`,
+    pl_PL: `Zaktualizowano BTCPay Server do 2.4.1, NBXplorer do 2.6.9 oraz narzędzie wdrażające aplikację Shopify do 1.9.
+
+**BTCPay Server 2.4.1**
+
+- Obsługa języków pisanych od prawej do lewej (RTL) (arabski, hebrajski, perski)
+- Import etykiet portfela BIP-329 i edytowalne komentarze do faktur
+- Poprawki płatności Boltcard i zgodności z Core Lightning; LNDHub jest teraz domyślnie włączony
+
+NBXplorer i narzędzie wdrażające Shopify otrzymują drobne aktualizacje konserwacyjne. Pełne informacje o wydaniu: https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.1`,
+    fr_FR: `BTCPay Server mis à jour vers 2.4.1, NBXplorer vers 2.6.9 et le déployeur d'application Shopify vers 1.9.
+
+**BTCPay Server 2.4.1**
+
+- Prise en charge des langues de droite à gauche (RTL) (arabe, hébreu, persan)
+- Import d'étiquettes de portefeuille BIP-329 et commentaires de facture modifiables
+- Corrections des paiements Boltcard et de la compatibilité Core Lightning ; LNDHub est désormais activé par défaut
+
+NBXplorer et le déployeur Shopify reçoivent des mises à jour de maintenance mineures. Notes de version complètes : https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.1`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps the BTCPay Server stack to the matched set that ships with upstream **BTCPay Server 2.4.1**, and moves the StartOS version `2.4.0:4 → 2.4.1:0`.

| Image | Old | New |
| --- | --- | --- |
| `btcpayserver/btcpayserver` | 2.4.0 | **2.4.1** |
| `nicolasdorier/nbxplorer` | 2.6.8 | **2.6.9** |
| `btcpayserver/postgres` | 18.4 | 18.4 (unchanged) |
| `btcpayserver/shopify-app-deployer` | 1.8 | **1.9** |

### Matched-set verification
The sidecar versions were cross-checked against the BTCPay team's canonical matched set in [`btcpayserver-docker`](https://github.com/btcpayserver/btcpayserver-docker) `docker-compose-generator/docker-fragments/*` on `master`, which pairs BTCPay 2.4.1 with NBXplorer `2.6.9`, Postgres `18.4`, and shopify-app-deployer `1.9`. Postgres is already at the matched `18.4`, so it is left unchanged.

### Artifacts verified to resolve
- `btcpayserver/btcpayserver:2.4.1` — Docker Hub, 3 arch images (published 2026-07-23)
- `nicolasdorier/nbxplorer:2.6.9` — Docker Hub (published 2026-07-21)
- `btcpayserver/shopify-app-deployer:1.9` — Docker Hub (published 2026-07-14)

## Upstream highlights (BTCPay Server 2.4.1)
- Right-to-left (RTL) language support (Arabic, Hebrew, Persian)
- BIP-329 wallet label import and editable invoice comments (incl. Greenfield/report support)
- Fixes for Boltcard payments and Core Lightning compatibility; LNDHub is now enabled by default

NBXplorer 2.6.9 is a maintenance release (allow `mingapsize == maxgapsize`, dotnet bump). Shopify deployer 1.9 bumps the embedded Shopify app to the 2026-04 API.

Full BTCPay release notes: https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.1

## SDK / dependencies
- `@start9labs/start-sdk` is already at the latest npm release (`2.0.7`) — no SDK bump.
- **`*-startos` git deps left as-is (no lockfile churn).** They were refreshed one cycle ago in #97, the lockfile carries exactly one hoisted `@start9labs/start-sdk` (2.0.7, no stale nested copies — the hazard a refresh guards against), and `monerod-startos`'s `#next` branch has since been merged to `master` and deleted upstream, so a clean blanket re-resolve isn't possible without re-pointing that dependency (out of scope for this upstream bump). The committed monerod lock SHA is still fetchable by commit, so `npm ci` remains green.

## Version
- `startos/versions/current.ts`: `2.4.0:4 → 2.4.1:0`, no migration (Docker-tag bumps only). Registry currently publishes only `2.4.0:4`, so `2.4.1:0` is free.

## Testing
- `npm run check` (tsc `--noEmit`) — green.