### PR TITLE
chore: bump BTCPay Server to 2.4.3-rc5, fix the 0.3.x migration abort, disable update notifications; 2.4.3-rc.4:1 → 2.4.3:0

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ Three models. Two are the applications' own INI configuration, and in both the p
 
 ### btcpayserver settings.config
 
-**Enforced** — rewritten to a fixed value whenever the package writes the file: `network`, `bind`, `btcexplorercookiefile`, `explorerpostgres`, `postgres`, `debuglog`, `dockerdeployment`, and the two Monero wallet-daemon paths. `BTC.explorer.cookiefile` is modelled as "must be absent" and is deleted if present — the correctly-cased key above replaces it.
+**Enforced** — rewritten to a fixed value whenever the package writes the file: `network`, `bind`, `btcexplorercookiefile`, `explorerpostgres`, `postgres`, `debuglog`, `dockerdeployment`, `updateurl`, and the two Monero wallet-daemon paths. `BTC.explorer.cookiefile` is modelled as "must be absent" and is deleted if present — the correctly-cased key above replaces it.
+
+Two of those keep BTCPay from advertising updates it cannot perform here, since StartOS does the updating: `dockerdeployment=false` hides the Maintenance page and its update button, and an empty `updateurl` disables the daily GitHub release check — which also removes the "check releases on GitHub" toggle from Server Settings → Policies and stops first-admin registration from switching it on. Plugin updates are a separate mechanism and still work normally from BTCPay's UI.
 
 **Written on every start**, from addresses resolved over the service bridge rather than stored: `socksendpoint` (Tor's SOCKS proxy), `XMR_daemon_uri` (when Monero is enabled), and the `server=` half of `btclightning` when the backend is LND. Editing any of these by hand does not survive a restart, and does not need to — they heal themselves when a dependency is installed, removed, or re-ported.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,1 +1,6 @@
 # TODO
+
+- [ ] **Move BTCPay Server back to `btcpayserver/btcpayserver` when 2.4.3 is published.** `2.4.3:0` pins the `btcpayserver-internal:2.4.3-rc5` prerelease image under a plain `2.4.3` version string, to carry rc5's security fixes ahead of upstream's release. It is a one-off; unwinding it puts the package back on the standard flow `UPDATING.md` describes:
+  - `startos/manifest/index.ts` → `images.btcpay.source.dockerTag` = `btcpayserver/btcpayserver:2.4.3`
+  - `startos/versions/current.ts` → `2.4.3:1`
+  - `README.md` → the two `btcpayserver/btcpayserver-internal` mentions (Images table, packaging summary)

--- a/UPDATING.md
+++ b/UPDATING.md
@@ -12,17 +12,6 @@ The package pulls **four** upstream images, each pinned as a `dockerTag` under `
 
   Pin lives in `startos/manifest/index.ts` → `images.btcpay.source.dockerTag` (`btcpayserver/btcpayserver:<version>`).
 
-  **Prerelease builds come from a different image repo.** Release candidates are published to `btcpayserver/btcpayserver-internal`, not `btcpayserver/btcpayserver`, and may exist with no corresponding GitHub release, tag, or changelog — upstream stages embargoed security fixes there ahead of disclosure. So an RC bump changes the image _repo_ as well as the tag. List them with:
-
-  ```sh
-  curl -fsSL "https://hub.docker.com/v2/repositories/btcpayserver/btcpayserver-internal/tags?page_size=50&ordering=last_updated" \
-    | jq -r '.results[].name'
-  ```
-
-  Move the pin back to `btcpayserver/btcpayserver` as soon as the final release is published.
-
-  **exver rejects a prerelease segment that mixes letters and digits**, so the upstream tag and the package version differ: upstream `2.4.3-rc4` must be written `2.4.3-rc.4:0` in `startos/versions/current.ts`. `rc4` fails to parse — the compile-time `ValidateExVer` on `VersionInfo.of` catches it. Ordering is unaffected: `2.4.2:1 < 2.4.3-rc.4:0 < 2.4.3:0`.
-
 - **NBXplorer** ([btcpayserver/NBXplorer](https://github.com/btcpayserver/NBXplorer)) — tagged on GitHub but no Releases are published. Strip the leading `v` for the `dockerTag`. The Docker image is published as `nicolasdorier/nbxplorer`. (The older `dgarage/NBXplorer` URL still works but 301-redirects to `btcpayserver/NBXplorer`, which is the canonical home today.)
 
   ```sh

--- a/startos/fileModels/btcpay.config.ts
+++ b/startos/fileModels/btcpay.config.ts
@@ -20,6 +20,9 @@ const shape = z.object({
   postgres: z.literal(btcpayPostgres).catch(btcpayPostgres),
   debuglog: z.literal('btcpay.log').catch('btcpay.log'),
   dockerdeployment: z.literal('false').catch('false'),
+  // empty disables the GitHub release check, hides its Policies toggle, and
+  // stops first-admin registration from enabling it — StartOS handles updates
+  updateurl: z.literal('').catch(''),
   XMR_daemon_uri: z.string().optional().catch(undefined),
   XMR_wallet_daemon_uri: z
     .literal(xmrWalletDaemonUri)

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -21,7 +21,7 @@ export const manifest = setupManifest({
   images: {
     btcpay: {
       source: {
-        dockerTag: 'btcpayserver/btcpayserver-internal:2.4.3-rc4',
+        dockerTag: 'btcpayserver/btcpayserver-internal:2.4.3-rc5',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,43 +1,53 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '2.4.3-rc.4:1',
+  version: '2.4.3:0',
   releaseNotes: {
-    en_US: `Updated NBXplorer to 2.6.11.
+    en_US: `Security update — BTCPay Server 2.4.3 — and a fix for a failed update from StartOS 0.3.x.
 
-A maintenance release with no changes to NBXplorer itself: it rebuilds on the .NET 10.0.11 runtime, which carries this month's .NET security fixes, and on NBitcoin 10.0.9.
+**About this version:** it ships BTCPay Server's 2.4.3 pre-release build (rc5) from BTCPay Server's internal image channel; upstream has not yet published a 2.4.3 release, git tag, or changelog. The security changes below were identified by comparing the published rc4 and rc5 images. This package will move to the final 2.4.3 build as soon as it is published.
 
-BTCPay Server stays on the 2.4.3-rc4 pre-release build shipped in the previous release.
+- **Crowdfund** — an app's description is no longer rendered as raw HTML, closing a cross-site scripting vector.
+- **Shopify plugin** — BTCPay Server now refuses to load outdated versions of the Shopify plugin and keeps them disabled until they are updated. If you use the Shopify integration, update the Shopify plugin under **Server Settings → Plugins** after this update; the newer plugin fixes a refund webhook vulnerability.
+- **Updating from StartOS 0.3.x** — the migration copied a plugins folder that only exists if you had installed a plugin. On a server that never did, the copy failed and took the whole update down with it, with no way past it on retry. The migration now skips what isn't there, and no longer reports success when a file copy fails partway, which could previously finish an update with data left behind.
 
-Full changes: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
-    es_ES: `NBXplorer actualizado a 2.6.11.
+Upstream's full release notes will appear at https://github.com/btcpayserver/btcpayserver/releases once 2.4.3 is published.`,
+    es_ES: `Actualización de seguridad — BTCPay Server 2.4.3 — y corrección de una actualización fallida desde StartOS 0.3.x.
 
-Una versión de mantenimiento sin cambios en NBXplorer: se recompila sobre el entorno de ejecución .NET 10.0.11, que incluye las correcciones de seguridad de .NET de este mes, y sobre NBitcoin 10.0.9.
+**Acerca de esta versión:** incluye la versión preliminar 2.4.3 (rc5) de BTCPay Server, tomada de su canal de imágenes interno; upstream aún no ha publicado una versión 2.4.3, ni etiqueta de git ni registro de cambios. Los cambios de seguridad siguientes se identificaron comparando las imágenes publicadas de rc4 y rc5. Este paquete pasará a la compilación final de 2.4.3 en cuanto se publique.
 
-BTCPay Server permanece en la versión preliminar 2.4.3-rc4 publicada en la versión anterior.
+- **Crowdfund** — la descripción de una aplicación ya no se representa como HTML sin procesar, lo que cierra un vector de scripting entre sitios.
+- **Complemento de Shopify** — BTCPay Server ahora se niega a cargar versiones desactualizadas del complemento de Shopify y las mantiene desactivadas hasta que se actualicen. Si utiliza la integración con Shopify, actualice el complemento de Shopify en **Configuración del servidor → Complementos** después de esta actualización; el complemento más reciente corrige una vulnerabilidad en el webhook de reembolsos.
+- **Actualizar desde StartOS 0.3.x** — la migración copiaba una carpeta de complementos que solo existe si había instalado alguno. En un servidor que nunca lo hizo, la copia fallaba y se llevaba consigo toda la actualización, sin forma de superarlo al reintentar. La migración ahora omite lo que no existe y ya no informa de éxito cuando una copia de archivos falla a medias, lo que antes podía terminar una actualización dejando datos atrás.
 
-Cambios completos: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
-    de_DE: `NBXplorer auf 2.6.11 aktualisiert.
+Las notas de versión completas aparecerán en https://github.com/btcpayserver/btcpayserver/releases cuando se publique 2.4.3.`,
+    de_DE: `Sicherheitsupdate — BTCPay Server 2.4.3 — und Behebung eines fehlgeschlagenen Updates von StartOS 0.3.x.
 
-Eine Wartungsversion ohne Änderungen an NBXplorer selbst: Sie wird auf der .NET-Laufzeit 10.0.11 neu gebaut, die die .NET-Sicherheitskorrekturen dieses Monats enthält, sowie auf NBitcoin 10.0.9.
+**Zu dieser Version:** Sie enthält den Vorabversions-Build 2.4.3 (rc5) von BTCPay Server aus dem internen Image-Kanal; upstream hat bislang weder eine 2.4.3-Veröffentlichung noch einen Git-Tag oder ein Changelog publiziert. Die folgenden Sicherheitsänderungen wurden durch einen Vergleich der veröffentlichten rc4- und rc5-Images ermittelt. Dieses Paket wechselt auf den finalen 2.4.3-Build, sobald dieser veröffentlicht ist.
 
-BTCPay Server bleibt beim Vorabversions-Build 2.4.3-rc4 aus der vorherigen Veröffentlichung.
+- **Crowdfund** — die Beschreibung einer App wird nicht mehr als rohes HTML gerendert, wodurch ein Cross-Site-Scripting-Vektor geschlossen wird.
+- **Shopify-Plugin** — BTCPay Server lädt veraltete Versionen des Shopify-Plugins nicht mehr und hält sie deaktiviert, bis sie aktualisiert werden. Wenn Sie die Shopify-Integration nutzen, aktualisieren Sie das Shopify-Plugin nach diesem Update unter **Servereinstellungen → Plugins**; das neuere Plugin behebt eine Schwachstelle im Rückerstattungs-Webhook.
+- **Update von StartOS 0.3.x** — die Migration kopierte einen Plugin-Ordner, den es nur gibt, wenn Sie ein Plugin installiert hatten. Auf einem Server ohne Plugin schlug das Kopieren fehl und riss das ganze Update mit sich, ohne dass ein erneuter Versuch daran vorbeikam. Die Migration überspringt jetzt, was nicht vorhanden ist, und meldet keinen Erfolg mehr, wenn ein Dateikopiervorgang mittendrin fehlschlägt — zuvor konnte ein Update so abschließen und Daten zurücklassen.
 
-Vollständige Änderungen: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
-    pl_PL: `Zaktualizowano NBXplorer do 2.6.11.
+Die vollständigen Release Notes erscheinen unter https://github.com/btcpayserver/btcpayserver/releases, sobald 2.4.3 veröffentlicht ist.`,
+    pl_PL: `Aktualizacja bezpieczeństwa — BTCPay Server 2.4.3 — oraz poprawka nieudanej aktualizacji ze StartOS 0.3.x.
 
-Wydanie konserwacyjne bez zmian w samym NBXplorerze: zostało przebudowane na środowisku uruchomieniowym .NET 10.0.11, które zawiera tegomiesięczne poprawki bezpieczeństwa .NET, oraz na NBitcoin 10.0.9.
+**O tej wersji:** zawiera przedpremierowy build 2.4.3 (rc5) BTCPay Server z wewnętrznego kanału obrazów; upstream nie opublikował jeszcze wydania 2.4.3, tagu git ani listy zmian. Poniższe zmiany bezpieczeństwa ustalono, porównując opublikowane obrazy rc4 i rc5. Pakiet przejdzie na finalny build 2.4.3, gdy tylko zostanie opublikowany.
 
-BTCPay Server pozostaje na wersji przedpremierowej 2.4.3-rc4 opublikowanej w poprzednim wydaniu.
+- **Crowdfund** — opis aplikacji nie jest już renderowany jako surowy HTML, co zamyka wektor ataku cross-site scripting.
+- **Wtyczka Shopify** — BTCPay Server odmawia teraz ładowania nieaktualnych wersji wtyczki Shopify i pozostawia je wyłączone do czasu aktualizacji. Jeśli korzystasz z integracji z Shopify, po tej aktualizacji zaktualizuj wtyczkę Shopify w **Ustawienia serwera → Wtyczki**; nowsza wtyczka naprawia lukę w webhooku zwrotów.
+- **Aktualizacja ze StartOS 0.3.x** — migracja kopiowała folder wtyczek, który istnieje tylko wtedy, gdy jakąś wtyczkę zainstalowano. Na serwerze bez wtyczek kopiowanie kończyło się błędem i przerywało całą aktualizację, a ponowna próba nic nie dawała. Migracja pomija teraz to, czego nie ma, i nie zgłasza już powodzenia, gdy kopiowanie plików zawiedzie w połowie — wcześniej aktualizacja mogła się zakończyć, zostawiając dane.
 
-Pełna lista zmian: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
-    fr_FR: `NBXplorer mis à jour vers 2.6.11.
+Pełne informacje o wydaniu pojawią się na https://github.com/btcpayserver/btcpayserver/releases po opublikowaniu wersji 2.4.3.`,
+    fr_FR: `Mise à jour de sécurité — BTCPay Server 2.4.3 — et correction d'une mise à jour échouée depuis StartOS 0.3.x.
 
-Une version de maintenance sans modification de NBXplorer lui-même : elle est reconstruite sur l'environnement d'exécution .NET 10.0.11, qui intègre les correctifs de sécurité .NET de ce mois-ci, ainsi que sur NBitcoin 10.0.9.
+**À propos de cette version :** elle embarque la version préliminaire 2.4.3 (rc5) de BTCPay Server, issue de son canal d'images interne ; en amont, 2.4.3 n'a encore ni version publiée, ni étiquette git, ni journal des modifications. Les changements de sécurité ci-dessous ont été identifiés en comparant les images rc4 et rc5 publiées. Ce paquet basculera sur la version finale de 2.4.3 dès sa publication.
 
-BTCPay Server reste sur la version préliminaire 2.4.3-rc4 publiée précédemment.
+- **Crowdfund** — la description d'une application n'est plus rendue en HTML brut, ce qui ferme un vecteur de script intersites.
+- **Extension Shopify** — BTCPay Server refuse désormais de charger les versions obsolètes de l'extension Shopify et les maintient désactivées jusqu'à leur mise à jour. Si vous utilisez l'intégration Shopify, mettez à jour l'extension Shopify dans **Paramètres du serveur → Extensions** après cette mise à jour ; la nouvelle extension corrige une vulnérabilité du webhook de remboursement.
+- **Mise à jour depuis StartOS 0.3.x** — la migration copiait un dossier d'extensions qui n'existe que si vous en aviez installé une. Sur un serveur qui n'en a jamais eu, la copie échouait et emportait toute la mise à jour, sans moyen de passer outre en réessayant. La migration ignore désormais ce qui est absent et ne signale plus un succès lorsqu'une copie de fichiers échoue en cours de route, ce qui pouvait auparavant terminer une mise à jour en laissant des données de côté.
 
-Changements complets : https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
+Les notes de version complètes apparaîtront sur https://github.com/btcpayserver/btcpayserver/releases une fois 2.4.3 publiée.`,
   },
   migrations: {},
 })

--- a/startos/versions/v2.4.0_2.ts
+++ b/startos/versions/v2.4.0_2.ts
@@ -73,11 +73,13 @@ async function migrateVolumes(effects: T.Effects) {
           'sh',
           '-c',
           `set -e
-          cd /mnt/main/btcpayserver
-          find . -mindepth 1 -maxdepth 1 ! -name altcoins -exec cp -a {} /mnt/btcpay/ \\;
-          if [ -d altcoins ]; then
-            mkdir -p /mnt/btcpay/altcoins
-            find altcoins -mindepth 1 -maxdepth 1 ! -name monero -exec cp -a {} /mnt/btcpay/altcoins/ \\;
+          if [ -d /mnt/main/btcpayserver ]; then
+            cd /mnt/main/btcpayserver
+            find . -mindepth 1 -maxdepth 1 ! -name altcoins -exec cp -a -t /mnt/btcpay/ {} +
+            if [ -d altcoins ]; then
+              mkdir -p /mnt/btcpay/altcoins
+              find altcoins -mindepth 1 -maxdepth 1 ! -name monero -exec cp -a -t /mnt/btcpay/altcoins/ {} +
+            fi
           fi`,
         ],
         { user: 'root' },
@@ -86,11 +88,25 @@ async function migrateVolumes(effects: T.Effects) {
         user: 'root',
       })
       await sub.execFail(
-        ['sh', '-c', 'cp -a /mnt/main/plugins/. /mnt/btcpay/Plugins/'],
+        [
+          'sh',
+          '-c',
+          `set -e
+          if [ -d /mnt/main/plugins ]; then
+            cp -a /mnt/main/plugins/. /mnt/btcpay/Plugins/
+          fi`,
+        ],
         { user: 'root' },
       )
       await sub.execFail(
-        ['sh', '-c', 'cp -a /mnt/main/nbxplorer/. /mnt/nbx/'],
+        [
+          'sh',
+          '-c',
+          `set -e
+          if [ -d /mnt/main/nbxplorer ]; then
+            cp -a /mnt/main/nbxplorer/. /mnt/nbx/
+          fi`,
+        ],
         { user: 'root' },
       )
 
@@ -99,9 +115,17 @@ async function migrateVolumes(effects: T.Effects) {
       // not in a data/ subdirectory. It detects PG 13, runs pg_upgrade, and places
       // the upgraded data at PGDATA (/var/lib/postgresql/data).
 
-      await sub.execFail(['sh', '-c', `cp -a ${OLD_PGDATA}/. ${PG_MOUNT}/`], {
-        user: 'root',
-      })
+      await sub.execFail(
+        [
+          'sh',
+          '-c',
+          `set -e
+          if [ -d ${OLD_PGDATA} ]; then
+            cp -a ${OLD_PGDATA}/. ${PG_MOUNT}/
+          fi`,
+        ],
+        { user: 'root' },
+      )
       await sub.execFail(['chown', '-R', 'postgres:postgres', PG_MOUNT], {
         user: 'root',
       })


### PR DESCRIPTION
Three changes shipping under one version, `2.4.3:0`.

## BTCPay Server 2.4.3-rc5 (security)

`images.btcpay.source.dockerTag` moves from `btcpayserver-internal:2.4.3-rc4` to `:2.4.3-rc5`. Upstream still has no published 2.4.3 release, git tag, or changelog — these were identified by diffing the published rc4 and rc5 images:

- **Crowdfund** — an app's description is no longer rendered as raw HTML, closing a cross-site scripting vector.
- **Shopify plugin** — BTCPay Server refuses to load outdated Shopify plugin builds and keeps them disabled until they are updated; the newer plugin fixes a refund webhook vulnerability.

NBXplorer, Postgres, and the Shopify app deployer are all already at their newest upstream (2.6.11 / 18.4 / 1.10) and are untouched.

## 0.3.x migration abort

Reported from the field: upgrading a StartOS 0.3.5.1 box running BTCPay 2.3.4 (monero altcoin enabled) to 2.4.0:4 on StartOS 0.4.0 fails the update with

```
Unknown Error: Error: sh failed with exit code 1: cp: cannot stat '/mnt/main/plugins/.': No such file or directory
```

`migrateVolumes` in `startos/versions/v2.4.0_2.ts` copies four source paths out of the old `main` volume and assumed every one of them exists. `/datadir/plugins` is BTCPay's `BTCPAY_PLUGINDIR`; nothing in the 0.3.x package creates it — only BTCPay does, and only once a plugin is actually installed. Monero in the 0.3.x package was the built-in `chains=btc,xmr` altcoin, not a marketplace plugin, so an install that never used one simply has no `/mnt/main/plugins`. `cp` exits 1, `execFail` throws, and the migration dies. It is a hard block, not a transient failure — every retry hits the same wall.

- Guard each copy on its source existing: `btcpayserver/`, `plugins/`, `nbxplorer/`, `postgresql/data`. Nothing to copy is not an error — the destination volumes come out empty either way.
- Switch the `btcpayserver` copy loops from `-exec cp -a {} \;` to `-exec cp -a -t DEST {} +`. GNU find does **not** propagate the exit status of a `\;` `-exec`, so a failed copy in that loop was silently ignored and the migration reported success with data missing. Confirmed against findutils 4.9.0 and 4.10.0: the `\;` form returns 0 with every copy failed, the `+` form returns 1.

Replayed inside `postgres:18.4` — the base image of the pinned `btcpayserver/postgres:18.4`, so GNU coreutils 9.7 and findutils 4.10.0, which is what makes `cp -t` and `-exec … +` available there — against a fixture reproducing the reporter's layout (`main/btcpayserver/{Main,altcoins/{monero,litecoin}}`, `main/nbxplorer`, `main/postgresql/data`, **no** `main/plugins`). Pre-fix reproduces the reported error verbatim. Post-fix all four steps exit 0 and land `Main/settings.config`, keep `altcoins/litecoin`, exclude `altcoins/monero`, create an empty `Plugins/`, copy nbxplorer, and place `PG_VERSION` at the db mount root where the entrypoint looks for it.

Affected boxes are re-runnable as-is: the failure happens before the `rm -rf` cleanup, so `/mnt/main` is intact and every step is a `cp -a` overwrite. The `+` form also aborts a mid-batch failure before that cleanup, so the source survives a retry rather than being wiped after a partial copy.

## Pin `updateurl` empty

BTCPay's daily GitHub release check drives a "New version released!" admin notification, pointing users at an upgrade path this package doesn't use — StartOS does the updating. An empty `updateurl` turns it off at three points rather than one:

- `GithubVersionFetcher.Fetch()` returns immediately when `UpdateUrl` is null.
- `UIServerController.cs:349` gates the Policies toggle on `ViewBag.UpdateUrlPresent`, so the "check releases on GitHub" checkbox isn't rendered and can't be switched on.
- `FirstAdminRegistered` is passed `options.UpdateUrl != null`, so registering the first admin no longer enables `CheckForNewVersions` — the only place it is ever assigned outside tests.

Verified that empty is the right value rather than assuming: `ConfigurationExtensions.cs:26-30` returns the default for a `Uri` when the string is null **or** empty, and the ini writer emits a bare `updateurl=` (the package already writes `XMR_daemon_username=` the same way).

**No behavior changes.** `updateurl` has never been written by this package in any release, 0.3.x included — checked across all 331 commits on every branch — so `UpdateUrl` was already null everywhere and the check has never run on StartOS. This pins it in the file model rather than leaving it to an omission: `merge()` never strips a key it doesn't name, so an `updateurl` arriving by any other route would have silently re-armed all three paths. No release-notes entry, since nothing observable changes.

Plugin and translation updates are a separate mechanism and stay available. `dockerdeployment=false` already hid the Maintenance page and its update button.

## Versioning — a one-off, not a new convention

Packaged as `2.4.3:0`, not `2.4.3-rc.5:0`. **This applies to rc5 and nothing else.** Ordering holds either way — `2.4.3-rc.4:1 < 2.4.3:0 < 2.4.3:1`, verified against the SDK's exver — so when upstream publishes 2.4.3 the pin goes back to `btcpayserver/btcpayserver` and the version to `2.4.3:1`, and the detour leaves no trace.

`UPDATING.md` goes back to the state it had before 4ce9154 added prerelease guidance to it, so it once again documents only the standard update flow. The deviation lives in `TODO.md` instead, as a checkbox listing everything that has to unwind — the pin, the version, and the two `btcpayserver-internal` mentions in `README.md`. The release notes carry the prerelease disclosure the version string no longer does.

The branch was rebased onto current `master`, dropping its stale `2.4.1:5` claim: `master` independently released `2.4.1:5` in the meantime and it is live on beta, so keeping that claim would have republished a permanent version with different bits.

Not exercised on a real box: the end-to-end 0.3.x → 0.4.x upgrade, and rc5 itself running.

> Note for whoever merges: `next` carries Helix's own rc5 bump as `2.4.3-rc.5:0` (`6a073a2`). It needs a rebase and its version claim dropped once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
