### PR TITLE
chore: bump Shopify app deployer to 1.10; 2.4.1:4 → 2.4.1:5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1600,7 +1600,7 @@
       }
     },
     "node_modules/cln-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#16b3466ff03c0f75ff09f689fc5b1fd0c7851d12",
+      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#e30fa2eab2e1001f40aed3d68e7d8bac1397f9ee",
       "dependencies": {
         "@start9labs/start-sdk": "2.0.7",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
@@ -1704,9 +1704,9 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#7881e414558146b8ab8325016d95af4c36dd8b4b",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#000f38e15950fc660efb9908dfa94b2fdbef9094",
       "dependencies": {
-        "@start9labs/start-sdk": "2.0.7",
+        "@start9labs/start-sdk": "2.0.9",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "mime": "^4.0.7",
         "rfc4648": "1.5.4",
@@ -1729,9 +1729,9 @@
       }
     },
     "node_modules/monerod-startos": {
-      "resolved": "git+ssh://git@github.com/Start9-Community/monerod-startos.git#bc8dafdd7404c5108c8f74aa0ffb07af9c52578a",
+      "resolved": "git+ssh://git@github.com/Start9-Community/monerod-startos.git#3ce2cfecfb3f0eb6619f8250a25c034b87753568",
       "dependencies": {
-        "@start9labs/start-sdk": "2.0.7",
+        "@start9labs/start-sdk": "2.0.9",
         "tor-startos": "github:Start9Labs/tor-startos#next"
       }
     },
@@ -1969,7 +1969,7 @@
       }
     },
     "node_modules/tor-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#e3e2b53a84cb92855ac7b35764df288fab1fa333",
+      "resolved": "git+ssh://git@github.com/Start9Labs/tor-startos.git#aa867cfea0f20095feb56e96cad3510393d912de",
       "dependencies": {
         "@noble/curves": "*",
         "@start9labs/start-sdk": "2.0.7",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -39,7 +39,7 @@ export const manifest = setupManifest({
     },
     shopify: {
       source: {
-        dockerTag: 'btcpayserver/shopify-app-deployer:1.9',
+        dockerTag: 'btcpayserver/shopify-app-deployer:1.10',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,23 +1,33 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '2.4.1:4',
+  version: '2.4.1:5',
   releaseNotes: {
-    en_US: `Uses a dedicated, trusted connection to Bitcoin for downloading blocks.
+    en_US: `Updated the Shopify integration to 1.10.
 
-BTCPay Server's block indexer, NBXplorer, pulls blocks from Bitcoin over the peer protocol. It was connecting on the same port as anonymous peers from the internet, so Bitcoin could drop the connection to make room for another peer, or cut it off under the limits that protect your upload bandwidth. It now uses a separate, local-only port that Bitcoin trusts. This requires Bitcoin to be updated first; StartOS will prompt you.`,
-    es_ES: `Usa una conexión dedicada y de confianza con Bitcoin para descargar bloques.
+While a customer's invoice is being created, the checkout now shows a "please wait" message next to the spinner instead of a bare spinner. This only affects stores using the optional Shopify integration; BTCPay Server itself is unchanged.
 
-El indexador de bloques de BTCPay Server, NBXplorer, obtiene bloques de Bitcoin mediante el protocolo entre pares. Se conectaba por el mismo puerto que los pares anónimos de internet, así que Bitcoin podía cortar la conexión para dejar sitio a otro par, o interrumpirla por los límites que protegen tu ancho de banda de subida. Ahora usa un puerto aparte, solo local, en el que Bitcoin confía. Para ello hay que actualizar antes Bitcoin; StartOS te lo pedirá.`,
-    de_DE: `Nutzt eine eigene, vertrauenswürdige Verbindung zu Bitcoin zum Herunterladen von Blöcken.
+Full changes: https://github.com/btcpayserver/shopify-app/compare/1.9...1.10`,
+    es_ES: `Actualiza la integración con Shopify a la versión 1.10.
 
-NBXplorer, der Block-Indexer von BTCPay Server, bezieht Blöcke über das Peer-Protokoll von Bitcoin. Er verband sich über denselben Port wie anonyme Gegenstellen aus dem Internet, sodass Bitcoin die Verbindung trennen konnte, um Platz für eine andere Gegenstelle zu schaffen, oder sie durch die Limits zum Schutz deiner Upload-Bandbreite unterbrach. Jetzt wird ein separater, rein lokaler Port genutzt, dem Bitcoin vertraut. Dafür muss zuerst Bitcoin aktualisiert werden; StartOS fordert dich dazu auf.`,
-    pl_PL: `Korzysta z dedykowanego, zaufanego połączenia z Bitcoin do pobierania bloków.
+Mientras se crea la factura de un cliente, la pantalla de pago muestra ahora un mensaje de «espera un momento» junto al indicador de carga, en vez de solo el indicador. Esto solo afecta a las tiendas que usan la integración opcional con Shopify; BTCPay Server no cambia.
 
-NBXplorer, indekser bloków BTCPay Server, pobiera bloki z Bitcoin przez protokół peer-to-peer. Łączył się tym samym portem co anonimowe węzły z internetu, więc Bitcoin mógł zerwać połączenie, by zrobić miejsce innemu węzłowi, albo przerwać je z powodu limitów chroniących twoje pasmo wysyłania. Teraz używa osobnego, wyłącznie lokalnego portu, któremu Bitcoin ufa. Wymaga to wcześniejszej aktualizacji Bitcoina; StartOS o tym przypomni.`,
-    fr_FR: `Utilise une connexion dédiée et de confiance vers Bitcoin pour télécharger les blocs.
+Todos los cambios: https://github.com/btcpayserver/shopify-app/compare/1.9...1.10`,
+    de_DE: `Aktualisiert die Shopify-Integration auf 1.10.
 
-NBXplorer, l'indexeur de blocs de BTCPay Server, récupère les blocs auprès de Bitcoin via le protocole pair-à-pair. Il se connectait sur le même port que les pairs anonymes d'internet, si bien que Bitcoin pouvait couper la connexion pour laisser la place à un autre pair, ou l'interrompre au titre des limites qui protègent votre bande passante montante. Il utilise désormais un port distinct, uniquement local, auquel Bitcoin fait confiance. Cela requiert de mettre d'abord à jour Bitcoin ; StartOS vous y invitera.`,
+Während die Rechnung einer Kundin oder eines Kunden erstellt wird, zeigt die Kasse jetzt neben dem Ladesymbol einen Hinweis zum Warten an statt nur des Ladesymbols. Das betrifft ausschließlich Shops mit der optionalen Shopify-Integration; BTCPay Server selbst bleibt unverändert.
+
+Alle Änderungen: https://github.com/btcpayserver/shopify-app/compare/1.9...1.10`,
+    pl_PL: `Aktualizuje integrację z Shopify do wersji 1.10.
+
+Podczas tworzenia faktury dla klienta ekran płatności pokazuje teraz obok wskaźnika ładowania komunikat z prośbą o chwilę cierpliwości, zamiast samego wskaźnika. Dotyczy to wyłącznie sklepów korzystających z opcjonalnej integracji z Shopify; sam BTCPay Server się nie zmienia.
+
+Pełna lista zmian: https://github.com/btcpayserver/shopify-app/compare/1.9...1.10`,
+    fr_FR: `Met à jour l'intégration Shopify vers la version 1.10.
+
+Pendant la création de la facture d'un client, la page de paiement affiche désormais un message d'attente à côté de l'indicateur de chargement, au lieu du seul indicateur. Cela ne concerne que les boutiques utilisant l'intégration Shopify facultative ; BTCPay Server lui-même est inchangé.
+
+Toutes les modifications : https://github.com/btcpayserver/shopify-app/compare/1.9...1.10`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Monitor cycle bump for `btcpayserver-startos`. **`2.4.1:4` → `2.4.1:5`.**

Of the four pinned images, only the **Shopify app deployer** moved upstream:

| Image | Pin | Status |
| --- | --- | --- |
| `btcpayserver/btcpayserver` | `2.4.1` | newest release (`v2.4.1`, 2026-07-23) — unchanged |
| `nicolasdorier/nbxplorer` | `2.6.9` | newest tag (`v2.6.9`) — unchanged |
| `btcpayserver/postgres` | `18.4` | newest multi-arch tag — unchanged |
| `btcpayserver/shopify-app-deployer` | `1.9` → **`1.10`** | bumped |

`btcpayserver`'s newest *tags* include `v2.4.2-rockstar-rc1/-rc2`, which are release candidates and are skipped.

### Artifact verification

`btcpayserver/shopify-app-deployer:1.10` resolves on Docker Hub (pushed 2026-08-03) and its manifest list carries `linux/amd64`, `linux/arm64` and `linux/arm/v7`, so both architectures this package builds for are covered.

### Upstream changes (`shopify-app` 1.9…1.10)

One commit, [`b741990`](https://github.com/btcpayserver/shopify-app/commit/b741990c) "Make checkout app more friendly": while the invoice is being created, the checkout extension now renders a "Please wait, BTCPay is generating your invoice…" line beside a larger spinner rather than a bare spinner. Copy/UX only — no API, config or deployment change. Full diff: <https://github.com/btcpayserver/shopify-app/compare/1.9...1.10>

This image only runs when the user enables the optional Shopify integration, so installs without it are unaffected.

### Other changes

- Re-resolved the `*-startos` git dependencies (`cln`, `lnd`, `monerod`, `tor` moved; `bitcoin-core` unchanged). 12-line lockfile diff, single hoisted `@start9labs/start-sdk`.
- `@start9labs/start-sdk` is already pinned at the latest published `2.0.9` — no SDK bump.
- No migration: the change is confined to the Shopify container image, with no on-disk state implications.
- `README.md` / `instructions.md` reviewed — neither carries image versions and neither describes the checkout UI, so no doc change is warranted.

## Test plan

- [x] `npm run check` (tsc) green at `2.4.1:5`
- [x] `prettier --check` clean on the edited files
- [x] `shopify-app-deployer:1.10` manifest verified on Docker Hub for amd64 + arm64
- [x] `2.4.1:5` confirmed free on the registry (published: `2.4.1:4`)
- [ ] `make` / s9pk build in review
