### PR TITLE
feat: prompt Lightning credential rotation after the 2.4.2 security fix; 2.4.2:0 → 2.4.2:1

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ Dependencies are dynamically resolved based on which features are enabled via ac
 | Mounted volume     | `main` → `/mnt/lnd` (read-only)                                        |
 | Purpose            | Lightning invoicing (when selected via "Choose Lightning Node" action) |
 
+The connection string points at LND's `admin.macaroon` on the mount, so the credential is read at connect time rather than copied — recreating LND's macaroons re-provisions BTCPay with no reconfiguration. See [Credential rotation migration](#credential-rotation-migration).
+
 ### Core Lightning (optional)
 
 | Property           | Value                                                                  |
@@ -238,6 +240,21 @@ Dependencies are dynamically resolved based on which features are enabled via ac
 | Health checks      | `lightningd`                                                           |
 | Mounted volume     | `main` → `/mnt/cln` (read-only)                                        |
 | Purpose            | Lightning invoicing (when selected via "Choose Lightning Node" action) |
+
+CLN is reached over its `lightning-rpc` Unix socket on the mount, which is unrestricted — there is no bearer token in the connection string, so nothing to rotate, but a compromised BTCPay could mint itself a rune through that socket. See [Credential rotation migration](#credential-rotation-migration).
+
+### Credential rotation migration
+
+`2.4.2:1`'s `up` migration raises a critical task against whichever Lightning backend `btclightning` names, so credentials BTCPay could reach before the 2.4.2 security fix get rotated:
+
+| `btclightning` | Task target                    | Rotates                                        |
+| -------------- | ------------------------------ | ---------------------------------------------- |
+| LND            | `lnd` → `recreate-macaroons`   | The admin macaroon BTCPay reads off the mount  |
+| CLN            | `c-lightning` → `revoke-runes` | Any rune mintable through the admin RPC socket |
+
+Two guards are load-bearing. The task is raised only when the backend is the configured one **and** that package is installed: a critical task stops this service and is cleared only by the _target_ service running the action, so raising one for an absent package would leave BTCPay unstartable short of a force-start. Neither the LND nor the CLN action existed in usable form before this release — `recreate-macaroons` left the macaroon root key in place until lnd-startos `0.21.1-beta:11`, and `revoke-runes` was added in cln-startos `26.6.6:9` — so the sibling pins must carry those versions.
+
+A user who pointed BTCPay at a node and later switched away is not detectable from `btclightning` alone, and a hot on-chain wallet's keys cannot be rotated at all; both are covered in the release notes and `instructions.md` instead.
 
 ### Monerod (optional)
 

--- a/README.md
+++ b/README.md
@@ -249,10 +249,12 @@ CLN is reached over its `lightning-rpc` Unix socket on the mount, which is unres
 
 | `btclightning` | Task target                    | Rotates                                        |
 | -------------- | ------------------------------ | ---------------------------------------------- |
-| LND            | `lnd` → `recreate-macaroons`   | The admin macaroon BTCPay reads off the mount  |
+| LND            | `lnd` → `revoke-macaroons`     | The admin macaroon BTCPay reads off the mount  |
 | CLN            | `c-lightning` → `revoke-runes` | Any rune mintable through the admin RPC socket |
 
-Two guards are load-bearing. The task is raised only when the backend is the configured one **and** that package is installed: a critical task stops this service and is cleared only by the _target_ service running the action, so raising one for an absent package would leave BTCPay unstartable short of a force-start. Neither the LND nor the CLN action existed in usable form before this release — `recreate-macaroons` left the macaroon root key in place until lnd-startos `0.21.1-beta:11`, and `revoke-runes` was added in cln-startos `26.6.6:9` — so the sibling pins must carry those versions.
+Two guards are load-bearing. The task is raised only when the backend is the configured one **and** that package is installed: a critical task stops this service and is cleared only by the _target_ service running the action, so raising one for an absent package would leave BTCPay unstartable short of a force-start.
+
+Neither action existed in usable form before this release — LND's was called `recreate-macaroons` and left the macaroon root key in place until `0.21.1-beta:11`, and `revoke-runes` was added in cln-startos `26.6.6:9`. `dependencies.ts` therefore floors both at those versions, so a user cannot end up with a task pointing at an action that does nothing.
 
 A user who pointed BTCPay at a node and later switched away is not detectable from `btclightning` alone, and a hot on-chain wallet's keys cannot be rotated at all; both are covered in the release notes and `instructions.md` instead.
 

--- a/instructions.md
+++ b/instructions.md
@@ -51,7 +51,7 @@ The vulnerability patched in BTCPay Server 2.4.2 was being actively exploited up
 
 If BTCPay is wired to a Lightning node, updating to 2.4.2:1 raises a **critical task** and stops BTCPay until you clear it. Running the action clears the task and BTCPay starts normally again.
 
-- **LND** — run LND's **Recreate Macaroons**. BTCPay reads LND's admin macaroon, which grants full control of the node. **Update LND to `0.21.1-beta:11` or later first:** earlier versions of that action deleted the macaroon files but left the root key they are signed with, so LND regenerated them from the same key and any copied macaroon kept working. BTCPay picks up the new macaroon from the same path automatically; other services connected to LND may need restarting.
+- **LND** — run LND's **Revoke Macaroons**. BTCPay reads LND's admin macaroon, which grants full control of the node. This needs LND `0.21.1-beta:11` or later, which BTCPay now requires: earlier releases called the action **Recreate Macaroons** and deleted the macaroon files while leaving the root key that signs them in place, so LND regenerated them from the same key and any copied macaroon kept working. BTCPay picks up the new macaroon from the same path automatically; other services connected to LND may need restarting.
 - **Core Lightning** — run Core Lightning's **Revoke All Runes** (added in `26.6.6:9`). BTCPay reaches CLN over its admin RPC socket, which is unrestricted, so a compromised server could have issued itself a rune that outlives the patch. CLN restarts afterwards to issue its web UI a fresh rune; re-issue any other integration's rune with **Create Rune**.
 
 Two things the update cannot do for you:

--- a/instructions.md
+++ b/instructions.md
@@ -45,8 +45,22 @@ You can point a custom domain (e.g. `donate.example.com`, `shop.example.com`) di
 
 StartOS backups include the BTCPay app data, the PostgreSQL `btcpayserver` database (users, stores, invoices), and the package configuration. The NBXplorer index is **not** backed up — on restore, NBXplorer resyncs from Bitcoin, which can take time before the Web UI becomes fully usable again.
 
+### Rotating Lightning credentials after the 2.4.2 update
+
+The vulnerability patched in BTCPay Server 2.4.2 was being actively exploited upstream. On any server that ran an earlier version, treat everything BTCPay could reach as exposed — **updating does not by itself undo access an attacker already took.**
+
+If BTCPay is wired to a Lightning node, updating to 2.4.2:1 raises a **critical task** and stops BTCPay until you clear it. Running the action clears the task and BTCPay starts normally again.
+
+- **LND** — run LND's **Recreate Macaroons**. BTCPay reads LND's admin macaroon, which grants full control of the node. **Update LND to `0.21.1-beta:11` or later first:** earlier versions of that action deleted the macaroon files but left the root key they are signed with, so LND regenerated them from the same key and any copied macaroon kept working. BTCPay picks up the new macaroon from the same path automatically; other services connected to LND may need restarting.
+- **Core Lightning** — run Core Lightning's **Revoke All Runes** (added in `26.6.6:9`). BTCPay reaches CLN over its admin RPC socket, which is unrestricted, so a compromised server could have issued itself a rune that outlives the patch. CLN restarts afterwards to issue its web UI a fresh rune; re-issue any other integration's rune with **Create Rune**.
+
+Two things the update cannot do for you:
+
+- **If you have ever pointed BTCPay at a Lightning node** — even if you have since switched away — rotate that node's credentials anyway. The task is only raised for the node BTCPay is wired to right now.
+- **If you generated a hot on-chain wallet inside BTCPay, move those funds** to a wallet whose keys BTCPay has never held. A hot wallet's keys cannot be rotated.
+
 ## Limitations
 
 - **Mainnet only.** Testnet and signet are not exposed by this package.
-- **One internal Lightning node at a time.** You can wire BTCPay to LND *or* CLN, not both simultaneously.
+- **One internal Lightning node at a time.** You can wire BTCPay to LND _or_ CLN, not both simultaneously.
 - **Reset Server Admin Password requires exactly one server admin.** If multiple admin accounts exist, use another admin account to reset the password through the Web UI instead.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1600,9 +1600,9 @@
       }
     },
     "node_modules/cln-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#e30fa2eab2e1001f40aed3d68e7d8bac1397f9ee",
+      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#97c99c105de4f4570931110d03ae119882f1f40f",
       "dependencies": {
-        "@start9labs/start-sdk": "2.0.7",
+        "@start9labs/start-sdk": "2.0.9",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
         "dotenv": "^17.2.0",
         "node-forge": "^1.3.1",
@@ -1704,7 +1704,7 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#000f38e15950fc660efb9908dfa94b2fdbef9094",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#5602827d75cca4210aa0f286aab63101ed4b4b99",
       "dependencies": {
         "@start9labs/start-sdk": "2.0.9",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",

--- a/startos/dependencies.ts
+++ b/startos/dependencies.ts
@@ -13,10 +13,14 @@ export const setDependencies = sdk.setupDependencies(async ({ effects }) => {
     .const(effects)
   if (!config) throw new Error('BTCPay config not found')
 
+  // Both floors are set by the credential-rotation task 2.4.2:1 raises (see
+  // versions/current.ts): revoke-macaroons only rotates LND's macaroon root key
+  // — the thing that actually revokes — from 0.21.1-beta:11, and revoke-runes
+  // does not exist before 26.6.6:9.
   if (isLnd(config.btclightning)) {
     deps['lnd'] = {
       kind: 'running',
-      versionRange: '>=0.21.1-beta:4',
+      versionRange: '>=0.21.1-beta:11',
       healthChecks: ['lnd'],
     }
   }
@@ -24,7 +28,7 @@ export const setDependencies = sdk.setupDependencies(async ({ effects }) => {
   if (isCln(config.btclightning)) {
     deps['c-lightning'] = {
       kind: 'running',
-      versionRange: '>=26.6.6:1',
+      versionRange: '>=26.6.6:9',
       healthChecks: ['lightningd'],
     }
   }

--- a/startos/i18n/dictionaries/default.ts
+++ b/startos/i18n/dictionaries/default.ts
@@ -57,6 +57,10 @@ const dict = {
 
   // dependencies.ts
   'BTCPay Server requires a particular block-notify command': 40,
+
+  // versions/current.ts
+  "BTCPay Server can read LND's admin macaroon, which may have been exposed by the vulnerability patched in 2.4.2. Recreate LND's macaroons to revoke the old ones.": 41,
+  "BTCPay Server reaches Core Lightning over its admin RPC socket, so a server compromised through the vulnerability patched in 2.4.2 could have issued itself a rune. Revoke this node's runes to invalidate any that were.": 42,
 } as const
 
 export type I18nKey = keyof typeof dict

--- a/startos/i18n/dictionaries/translations.ts
+++ b/startos/i18n/dictionaries/translations.ts
@@ -43,6 +43,8 @@ export default {
     38: 'Interfaz web',
     39: 'La interfaz web para interactuar con BTCPay Server en un navegador.',
     40: 'BTCPay Server requiere un comando block-notify especifico',
+    41: 'BTCPay Server puede leer el macaroon de administrador de LND, que pudo quedar expuesto por la vulnerabilidad corregida en 2.4.2. Vuelva a crear los macaroons de LND para revocar los anteriores.',
+    42: 'BTCPay Server se comunica con Core Lightning por su socket RPC de administracion, asi que un servidor comprometido a traves de la vulnerabilidad corregida en 2.4.2 pudo emitirse una runa. Revoque las runas de este nodo para invalidar cualquiera que se haya emitido.',
   } satisfies LangDict,
   de_DE: {
     0: 'UTXO-Tracker',
@@ -86,6 +88,8 @@ export default {
     38: 'Web-UI',
     39: 'Die Weboberflache fur die Interaktion mit BTCPay Server in einem Browser.',
     40: 'BTCPay Server benotigt einen bestimmten block-notify-Befehl',
+    41: 'BTCPay Server kann das Admin-Macaroon von LND lesen, das durch die in 2.4.2 behobene Sicherheitslucke offengelegt worden sein kann. Erstellen Sie die Macaroons von LND neu, um die alten zu widerrufen.',
+    42: 'BTCPay Server erreicht Core Lightning uber dessen Admin-RPC-Socket, sodass ein uber die in 2.4.2 behobene Sicherheitslucke kompromittierter Server sich selbst eine Rune ausgestellt haben konnte. Widerrufen Sie die Runes dieses Nodes, um alle so entstandenen ungultig zu machen.',
   } satisfies LangDict,
   pl_PL: {
     0: 'Sledzenie UTXO',
@@ -129,6 +133,8 @@ export default {
     38: 'Interfejs webowy',
     39: 'Interfejs webowy do interakcji z BTCPay Server w przegladarce.',
     40: 'BTCPay Server wymaga konkretnego polecenia block-notify',
+    41: 'BTCPay Server moze odczytac macaroon administratora LND, ktory mogl zostac ujawniony przez luke naprawiona w wersji 2.4.2. Utworz ponownie macaroony LND, aby uniewaznic poprzednie.',
+    42: 'BTCPay Server laczy sie z Core Lightning przez jego administracyjne gniazdo RPC, wiec serwer przejety przez luke naprawiona w wersji 2.4.2 mogl wydac sobie rune. Uniewaznij runy tego wezla, aby anulowac wszystkie tak wydane.',
   } satisfies LangDict,
   fr_FR: {
     0: 'Suivi UTXO',
@@ -172,5 +178,7 @@ export default {
     38: 'Interface web',
     39: "L'interface web pour interagir avec BTCPay Server dans un navigateur.",
     40: 'BTCPay Server requiert une commande block-notify specifique',
+    41: 'BTCPay Server peut lire le macaroon administrateur de LND, qui a pu etre expose par la vulnerabilite corrigee dans la version 2.4.2. Recreez les macaroons de LND pour revoquer les anciens.',
+    42: "BTCPay Server atteint Core Lightning via son socket RPC d'administration : un serveur compromis par la vulnerabilite corrigee dans la version 2.4.2 a donc pu s'emettre une rune. Revoquez les runes de ce noeud pour invalider toutes celles qui auraient ete creees.",
   } satisfies LangDict,
 } as const

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,68 +1,114 @@
 import { VersionInfo } from '@start9labs/start-sdk'
+import { revokeRunes } from 'cln-startos/startos/actions/revokeRunes'
+import { recreateMacaroons } from 'lnd-startos/startos/actions/recreate-macaroons'
+import { btcpayConfig } from '../fileModels/btcpay.config'
+import { i18n } from '../i18n'
+import { sdk } from '../sdk'
+import { isCln, isLnd } from '../utils'
 
 export const current = VersionInfo.of({
-  version: '2.4.2:0',
+  version: '2.4.2:1',
   releaseNotes: {
-    en_US: `Updated BTCPay Server to 2.4.2 and NBXplorer to 2.6.10.
+    en_US: `Prompts you to replace your Lightning node's credentials after the 2.4.2 security update.
 
-**This is a critical security release — upstream reports the vulnerability is being actively exploited, so update as soon as possible.**
+The vulnerability patched in 2.4.2 was being actively exploited, so on any server that ran an earlier build, treat everything BTCPay Server could reach as exposed. **Updating does not by itself undo access an attacker already took.**
 
-- Fixed a two-factor authentication (TOTP) bypass through the Greenfield API's Basic authentication
-- Basic authentication on the Greenfield API is now disabled by default five minutes after account creation; it can be re-enabled in account settings if an integration needs it
-- More reliable multisig PSBT signing and finalization, including with newer HWI and Jade firmware
-- Right-to-left (RTL) stylesheets now load correctly
-- Wallet transaction table columns can be hidden, shown, and reordered
-- Cleaner store settings pages; public invoice creation for payment requests is now rate limited
+If BTCPay Server is wired to a Lightning node, updating raises a critical task and stops BTCPay Server until you clear it:
 
-NBXplorer 2.6.10 is the version upstream recommends alongside this release. Full release notes: https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.2`,
-    es_ES: `Se actualizó BTCPay Server a 2.4.2 y NBXplorer a 2.6.10.
+- **LND** — run LND's "Recreate Macaroons" action. BTCPay Server reads LND's admin macaroon, which grants full control of the node. Update LND first: before \`0.21.1-beta:11\` that action left the macaroon root key in place, so it did not actually revoke anything.
+- **Core Lightning** — run Core Lightning's "Revoke All Runes" action. BTCPay Server reaches CLN over its admin RPC socket, so a compromised server could have issued itself a rune that outlives the patch.
 
-**Esta es una versión de seguridad crítica: el proyecto original informa de que la vulnerabilidad se está explotando activamente, así que actualiza lo antes posible.**
+Two things this update cannot do for you:
 
-- Se corrigió una omisión de la autenticación de dos factores (TOTP) a través de la autenticación básica de la API Greenfield
-- La autenticación básica de la API Greenfield ahora se desactiva de forma predeterminada cinco minutos después de crear la cuenta; puede reactivarse en los ajustes de la cuenta si una integración la necesita
-- Firma y finalización de PSBT multifirma más fiables, incluso con firmware reciente de HWI y Jade
-- Las hojas de estilo de derecha a izquierda (RTL) ahora se cargan correctamente
-- Las columnas de la tabla de transacciones del monedero se pueden ocultar, mostrar y reordenar
-- Páginas de configuración de la tienda más claras; la creación pública de facturas para solicitudes de pago ahora tiene límite de frecuencia
+- **If you have ever connected BTCPay Server to a Lightning node** — even if you have since switched away — rotate that node's credentials anyway. The task is only raised for the node BTCPay Server is wired to right now.
+- **If you generated a hot on-chain wallet inside BTCPay Server, move those funds** to a wallet whose keys BTCPay Server has never held. A hot wallet's keys cannot be rotated.`,
+    es_ES: `Te pide sustituir las credenciales de tu nodo Lightning tras la actualización de seguridad 2.4.2.
 
-NBXplorer 2.6.10 es la versión que el proyecto original recomienda junto con esta actualización. Notas de la versión completas: https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.2`,
-    de_DE: `BTCPay Server auf 2.4.2 und NBXplorer auf 2.6.10 aktualisiert.
+La vulnerabilidad corregida en 2.4.2 se estaba explotando activamente, así que en cualquier servidor que ejecutara una versión anterior debes considerar expuesto todo lo que BTCPay Server podía alcanzar. **Actualizar por sí solo no revierte el acceso que un atacante ya haya obtenido.**
 
-**Dies ist ein kritisches Sicherheitsupdate – laut Upstream wird die Schwachstelle aktiv ausgenutzt, daher so bald wie möglich aktualisieren.**
+Si BTCPay Server está conectado a un nodo Lightning, la actualización genera una tarea crítica y detiene BTCPay Server hasta que la resuelvas:
 
-- Eine Umgehung der Zwei-Faktor-Authentifizierung (TOTP) über die Basic-Authentifizierung der Greenfield-API wurde behoben
-- Die Basic-Authentifizierung der Greenfield-API wird jetzt standardmäßig fünf Minuten nach der Kontoerstellung deaktiviert; wer sie für eine Integration benötigt, kann sie in den Kontoeinstellungen wieder aktivieren
-- Zuverlässigeres Signieren und Finalisieren von Multisig-PSBTs, auch mit neuerer HWI- und Jade-Firmware
-- Stylesheets für Rechts-nach-links-Sprachen (RTL) werden wieder korrekt geladen
-- Spalten der Transaktionstabelle im Wallet lassen sich aus- und einblenden sowie neu anordnen
-- Übersichtlichere Shop-Einstellungsseiten; die öffentliche Rechnungserstellung für Zahlungsanfragen ist jetzt ratenbegrenzt
+- **LND** — ejecuta la acción «Recrear Macaroons» de LND. BTCPay Server lee el macaroon de administrador de LND, que otorga control total del nodo. Actualiza LND primero: antes de \`0.21.1-beta:11\` esa acción dejaba intacta la clave raíz de los macaroons, así que en realidad no revocaba nada.
+- **Core Lightning** — ejecuta la acción «Revocar todas las runas» de Core Lightning. BTCPay Server se comunica con CLN por su socket RPC de administración, así que un servidor comprometido pudo emitirse una runa que sobrevive al parche.
 
-NBXplorer 2.6.10 ist die Version, die Upstream zusammen mit diesem Update empfiehlt. Vollständige Versionshinweise: https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.2`,
-    pl_PL: `Zaktualizowano BTCPay Server do 2.4.2 i NBXplorer do 2.6.10.
+Dos cosas que esta actualización no puede hacer por ti:
 
-**To krytyczna aktualizacja bezpieczeństwa — według twórców luka jest aktywnie wykorzystywana, dlatego zaktualizuj jak najszybciej.**
+- **Si alguna vez conectaste BTCPay Server a un nodo Lightning** —aunque ya hayas cambiado a otra opción—, rota igualmente las credenciales de ese nodo. La tarea solo se genera para el nodo al que BTCPay Server está conectado ahora mismo.
+- **Si generaste un monedero caliente on-chain dentro de BTCPay Server, mueve esos fondos** a un monedero cuyas claves BTCPay Server nunca haya tenido. Las claves de un monedero caliente no se pueden rotar.`,
+    de_DE: `Fordert Sie nach dem Sicherheitsupdate 2.4.2 auf, die Zugangsdaten Ihres Lightning-Knotens zu ersetzen.
 
-- Naprawiono obejście uwierzytelniania dwuskładnikowego (TOTP) poprzez uwierzytelnianie Basic w API Greenfield
-- Uwierzytelnianie Basic w API Greenfield jest teraz domyślnie wyłączane pięć minut po utworzeniu konta; w razie potrzeby integracji można je ponownie włączyć w ustawieniach konta
-- Bardziej niezawodne podpisywanie i finalizowanie transakcji multisig (PSBT), także z nowszym oprogramowaniem HWI i Jade
-- Arkusze stylów dla języków pisanych od prawej do lewej (RTL) ładują się teraz poprawnie
-- Kolumny tabeli transakcji portfela można ukrywać, pokazywać i zmieniać ich kolejność
-- Czytelniejsze strony ustawień sklepu; publiczne tworzenie faktur dla żądań płatności ma teraz limit częstotliwości
+Die in 2.4.2 behobene Sicherheitslücke wurde aktiv ausgenutzt. Auf jedem Server, der eine ältere Version ausgeführt hat, sollten Sie daher alles als offengelegt betrachten, was BTCPay Server erreichen konnte. **Das Update allein macht einen bereits erfolgten Zugriff nicht rückgängig.**
 
-NBXplorer 2.6.10 to wersja zalecana przez twórców razem z tą aktualizacją. Pełne informacje o wydaniu: https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.2`,
-    fr_FR: `BTCPay Server mis à jour vers 2.4.2 et NBXplorer vers 2.6.10.
+Wenn BTCPay Server mit einem Lightning-Knoten verbunden ist, erzeugt das Update eine kritische Aufgabe und stoppt BTCPay Server, bis Sie sie erledigen:
 
-**Il s'agit d'une mise à jour de sécurité critique — le projet amont signale que la vulnérabilité est activement exploitée, mettez donc à jour au plus vite.**
+- **LND** — führen Sie die LND-Aktion „Macaroons neu erstellen“ aus. BTCPay Server liest das Admin-Macaroon von LND, das vollständige Kontrolle über den Knoten gewährt. Aktualisieren Sie LND zuerst: vor \`0.21.1-beta:11\` ließ diese Aktion den Macaroon-Root-Schlüssel bestehen und widerrief daher tatsächlich nichts.
+- **Core Lightning** — führen Sie die Core-Lightning-Aktion „Alle Runes widerrufen“ aus. BTCPay Server erreicht CLN über dessen Admin-RPC-Socket, sodass ein kompromittierter Server sich selbst eine Rune ausgestellt haben könnte, die den Patch überdauert.
 
-- Correction d'un contournement de l'authentification à deux facteurs (TOTP) via l'authentification Basic de l'API Greenfield
-- L'authentification Basic de l'API Greenfield est désormais désactivée par défaut cinq minutes après la création du compte ; elle peut être réactivée dans les paramètres du compte si une intégration en a besoin
-- Signature et finalisation des PSBT multisignature plus fiables, y compris avec les micrologiciels HWI et Jade récents
-- Les feuilles de style pour les langues de droite à gauche (RTL) se chargent de nouveau correctement
-- Les colonnes du tableau des transactions du portefeuille peuvent être masquées, affichées et réordonnées
-- Pages de paramètres de la boutique plus lisibles ; la création publique de factures pour les demandes de paiement est désormais limitée en fréquence
+Zwei Dinge, die dieses Update nicht für Sie erledigen kann:
 
-NBXplorer 2.6.10 est la version recommandée par le projet amont avec cette mise à jour. Notes de version complètes : https://github.com/btcpayserver/btcpayserver/releases/tag/v2.4.2`,
+- **Wenn Sie BTCPay Server jemals mit einem Lightning-Knoten verbunden haben** – auch wenn Sie inzwischen gewechselt sind –, wechseln Sie die Zugangsdaten dieses Knotens trotzdem. Die Aufgabe wird nur für den Knoten erzeugt, mit dem BTCPay Server aktuell verbunden ist.
+- **Wenn Sie in BTCPay Server eine On-Chain-Hot-Wallet erzeugt haben, verschieben Sie diese Mittel** in eine Wallet, deren Schlüssel BTCPay Server nie besessen hat. Die Schlüssel einer Hot Wallet lassen sich nicht wechseln.`,
+    pl_PL: `Przypomina o wymianie poświadczeń węzła Lightning po aktualizacji bezpieczeństwa 2.4.2.
+
+Luka naprawiona w wersji 2.4.2 była aktywnie wykorzystywana, więc na każdym serwerze, na którym działała wcześniejsza wersja, uznaj za ujawnione wszystko, do czego BTCPay Server miał dostęp. **Sama aktualizacja nie cofa dostępu, który atakujący już uzyskał.**
+
+Jeśli BTCPay Server jest połączony z węzłem Lightning, aktualizacja tworzy zadanie krytyczne i zatrzymuje BTCPay Server do czasu jego wykonania:
+
+- **LND** — uruchom akcję „Odtwórz Macaroons” w LND. BTCPay Server odczytuje macaroon administratora LND, który daje pełną kontrolę nad węzłem. Najpierw zaktualizuj LND: przed wersją \`0.21.1-beta:11\` ta akcja pozostawiała klucz główny macaroonów, więc w rzeczywistości niczego nie unieważniała.
+- **Core Lightning** — uruchom akcję „Unieważnij wszystkie runy” w Core Lightning. BTCPay Server łączy się z CLN przez jego administracyjne gniazdo RPC, więc przejęty serwer mógł wydać sobie runę, która przetrwa załatanie luki.
+
+Dwie rzeczy, których ta aktualizacja nie zrobi za ciebie:
+
+- **Jeśli kiedykolwiek łączyłeś BTCPay Server z węzłem Lightning** — nawet jeśli od tego czasu zmieniłeś konfigurację — i tak wymień poświadczenia tego węzła. Zadanie tworzone jest tylko dla węzła, z którym BTCPay Server jest połączony obecnie.
+- **Jeśli utworzyłeś w BTCPay Server gorący portfel on-chain, przenieś te środki** do portfela, którego kluczy BTCPay Server nigdy nie posiadał. Kluczy gorącego portfela nie da się wymienić.`,
+    fr_FR: `Vous invite à remplacer les identifiants de votre nœud Lightning après la mise à jour de sécurité 2.4.2.
+
+La vulnérabilité corrigée dans la version 2.4.2 était activement exploitée : sur tout serveur ayant exécuté une version antérieure, considérez comme exposé tout ce que BTCPay Server pouvait atteindre. **La mise à jour seule n'annule pas un accès déjà obtenu par un attaquant.**
+
+Si BTCPay Server est relié à un nœud Lightning, la mise à jour crée une tâche critique et arrête BTCPay Server jusqu'à ce que vous la traitiez :
+
+- **LND** — lancez l'action « Recréer les Macaroons » de LND. BTCPay Server lit le macaroon administrateur de LND, qui donne un contrôle total du nœud. Mettez d'abord LND à jour : avant \`0.21.1-beta:11\`, cette action laissait en place la clé racine des macaroons et ne révoquait donc rien en réalité.
+- **Core Lightning** — lancez l'action « Révoquer toutes les runes » de Core Lightning. BTCPay Server atteint CLN via son socket RPC d'administration : un serveur compromis a donc pu s'émettre une rune qui survit au correctif.
+
+Deux choses que cette mise à jour ne peut pas faire à votre place :
+
+- **Si vous avez déjà relié BTCPay Server à un nœud Lightning** — même si vous en avez changé depuis —, renouvelez tout de même les identifiants de ce nœud. La tâche n'est créée que pour le nœud auquel BTCPay Server est relié actuellement.
+- **Si vous avez généré un portefeuille chaud on-chain dans BTCPay Server, déplacez ces fonds** vers un portefeuille dont BTCPay Server n'a jamais détenu les clés. Les clés d'un portefeuille chaud ne peuvent pas être renouvelées.`,
   },
-  migrations: {},
+  migrations: {
+    up: async ({ effects }) => {
+      const backend = await btcpayConfig.read((s) => s.btclightning).once()
+
+      // A critical task stops this service until the target action is run, and
+      // only the target service running it clears the task — so raising one for
+      // a package that is not installed would leave BTCPay Server unstartable.
+      const installed = await effects.getInstalledPackages()
+
+      if (isLnd(backend) && installed.includes('lnd'))
+        await sdk.action.createTask(
+          effects,
+          'lnd',
+          recreateMacaroons,
+          'critical',
+          {
+            reason: i18n(
+              "BTCPay Server can read LND's admin macaroon, which may have been exposed by the vulnerability patched in 2.4.2. Recreate LND's macaroons to revoke the old ones.",
+            ),
+          },
+        )
+
+      if (isCln(backend) && installed.includes('c-lightning'))
+        await sdk.action.createTask(
+          effects,
+          'c-lightning',
+          revokeRunes,
+          'critical',
+          {
+            reason: i18n(
+              "BTCPay Server reaches Core Lightning over its admin RPC socket, so a server compromised through the vulnerability patched in 2.4.2 could have issued itself a rune. Revoke this node's runes to invalidate any that were.",
+            ),
+          },
+        )
+    },
+  },
 })

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,6 +1,8 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 import { revokeRunes } from 'cln-startos/startos/actions/revokeRunes'
+import { manifest as clnManifest } from 'cln-startos/startos/manifest'
 import { revokeMacaroons } from 'lnd-startos/startos/actions/revoke-macaroons'
+import { manifest as lndManifest } from 'lnd-startos/startos/manifest'
 import { btcpayConfig } from '../fileModels/btcpay.config'
 import { i18n } from '../i18n'
 import { sdk } from '../sdk'
@@ -82,12 +84,12 @@ Deux choses que cette mise à jour ne peut pas faire à votre place :
       // A critical task stops this service until the target action is run, and
       // only the target service running it clears the task — so raising one for
       // a package that is not installed would leave BTCPay Server unstartable.
-      const installed = await effects.getInstalledPackages()
+      const installed = await sdk.getInstalledPackages(effects)
 
-      if (isLnd(backend) && installed.includes('lnd'))
+      if (isLnd(backend) && installed.includes(lndManifest.id))
         await sdk.action.createTask(
           effects,
-          'lnd',
+          lndManifest.id,
           revokeMacaroons,
           'critical',
           {
@@ -97,10 +99,10 @@ Deux choses que cette mise à jour ne peut pas faire à votre place :
           },
         )
 
-      if (isCln(backend) && installed.includes('c-lightning'))
+      if (isCln(backend) && installed.includes(clnManifest.id))
         await sdk.action.createTask(
           effects,
-          'c-lightning',
+          clnManifest.id,
           revokeRunes,
           'critical',
           {

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,6 +1,6 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 import { revokeRunes } from 'cln-startos/startos/actions/revokeRunes'
-import { recreateMacaroons } from 'lnd-startos/startos/actions/recreate-macaroons'
+import { revokeMacaroons } from 'lnd-startos/startos/actions/revoke-macaroons'
 import { btcpayConfig } from '../fileModels/btcpay.config'
 import { i18n } from '../i18n'
 import { sdk } from '../sdk'
@@ -15,7 +15,7 @@ The vulnerability patched in 2.4.2 was being actively exploited, so on any serve
 
 If BTCPay Server is wired to a Lightning node, updating raises a critical task and stops BTCPay Server until you clear it:
 
-- **LND** — run LND's "Recreate Macaroons" action. BTCPay Server reads LND's admin macaroon, which grants full control of the node. Update LND first: before \`0.21.1-beta:11\` that action left the macaroon root key in place, so it did not actually revoke anything.
+- **LND** — run LND's "Revoke Macaroons" action. BTCPay Server reads LND's admin macaroon, which grants full control of the node. This needs LND \`0.21.1-beta:11\` or later, now required as a dependency: earlier releases called the action "Recreate Macaroons" and only deleted the macaroon files, leaving the root key that signs them in place, so nothing was actually revoked.
 - **Core Lightning** — run Core Lightning's "Revoke All Runes" action. BTCPay Server reaches CLN over its admin RPC socket, so a compromised server could have issued itself a rune that outlives the patch.
 
 Two things this update cannot do for you:
@@ -28,7 +28,7 @@ La vulnerabilidad corregida en 2.4.2 se estaba explotando activamente, así que 
 
 Si BTCPay Server está conectado a un nodo Lightning, la actualización genera una tarea crítica y detiene BTCPay Server hasta que la resuelvas:
 
-- **LND** — ejecuta la acción «Recrear Macaroons» de LND. BTCPay Server lee el macaroon de administrador de LND, que otorga control total del nodo. Actualiza LND primero: antes de \`0.21.1-beta:11\` esa acción dejaba intacta la clave raíz de los macaroons, así que en realidad no revocaba nada.
+- **LND** — ejecuta la acción «Revocar macaroons» de LND. BTCPay Server lee el macaroon de administrador de LND, que otorga control total del nodo. Requiere LND \`0.21.1-beta:11\` o posterior, ahora exigido como dependencia: en versiones anteriores la acción se llamaba «Recrear Macaroons» y solo borraba los archivos de macaroons, dejando intacta la clave raíz que los firma, así que no revocaba nada.
 - **Core Lightning** — ejecuta la acción «Revocar todas las runas» de Core Lightning. BTCPay Server se comunica con CLN por su socket RPC de administración, así que un servidor comprometido pudo emitirse una runa que sobrevive al parche.
 
 Dos cosas que esta actualización no puede hacer por ti:
@@ -41,7 +41,7 @@ Die in 2.4.2 behobene Sicherheitslücke wurde aktiv ausgenutzt. Auf jedem Server
 
 Wenn BTCPay Server mit einem Lightning-Knoten verbunden ist, erzeugt das Update eine kritische Aufgabe und stoppt BTCPay Server, bis Sie sie erledigen:
 
-- **LND** — führen Sie die LND-Aktion „Macaroons neu erstellen“ aus. BTCPay Server liest das Admin-Macaroon von LND, das vollständige Kontrolle über den Knoten gewährt. Aktualisieren Sie LND zuerst: vor \`0.21.1-beta:11\` ließ diese Aktion den Macaroon-Root-Schlüssel bestehen und widerrief daher tatsächlich nichts.
+- **LND** — führen Sie die LND-Aktion „Macaroons widerrufen“ aus. BTCPay Server liest das Admin-Macaroon von LND, das vollständige Kontrolle über den Knoten gewährt. Dafür wird LND \`0.21.1-beta:11\` oder neuer benötigt, jetzt als Abhängigkeit vorausgesetzt: davor hieß die Aktion „Macaroons neu erstellen“ und löschte nur die Macaroon-Dateien, ließ aber den signierenden Root-Schlüssel bestehen und widerrief damit nichts.
 - **Core Lightning** — führen Sie die Core-Lightning-Aktion „Alle Runes widerrufen“ aus. BTCPay Server erreicht CLN über dessen Admin-RPC-Socket, sodass ein kompromittierter Server sich selbst eine Rune ausgestellt haben könnte, die den Patch überdauert.
 
 Zwei Dinge, die dieses Update nicht für Sie erledigen kann:
@@ -54,7 +54,7 @@ Luka naprawiona w wersji 2.4.2 była aktywnie wykorzystywana, więc na każdym s
 
 Jeśli BTCPay Server jest połączony z węzłem Lightning, aktualizacja tworzy zadanie krytyczne i zatrzymuje BTCPay Server do czasu jego wykonania:
 
-- **LND** — uruchom akcję „Odtwórz Macaroons” w LND. BTCPay Server odczytuje macaroon administratora LND, który daje pełną kontrolę nad węzłem. Najpierw zaktualizuj LND: przed wersją \`0.21.1-beta:11\` ta akcja pozostawiała klucz główny macaroonów, więc w rzeczywistości niczego nie unieważniała.
+- **LND** — uruchom akcję „Unieważnij macaroons” w LND. BTCPay Server odczytuje macaroon administratora LND, który daje pełną kontrolę nad węzłem. Wymaga to LND \`0.21.1-beta:11\` lub nowszego, teraz wymaganego jako zależność: wcześniej akcja nazywała się „Odtwórz Macaroons” i usuwała tylko pliki macaroonów, pozostawiając podpisujący je klucz główny, więc niczego nie unieważniała.
 - **Core Lightning** — uruchom akcję „Unieważnij wszystkie runy” w Core Lightning. BTCPay Server łączy się z CLN przez jego administracyjne gniazdo RPC, więc przejęty serwer mógł wydać sobie runę, która przetrwa załatanie luki.
 
 Dwie rzeczy, których ta aktualizacja nie zrobi za ciebie:
@@ -67,7 +67,7 @@ La vulnérabilité corrigée dans la version 2.4.2 était activement exploitée 
 
 Si BTCPay Server est relié à un nœud Lightning, la mise à jour crée une tâche critique et arrête BTCPay Server jusqu'à ce que vous la traitiez :
 
-- **LND** — lancez l'action « Recréer les Macaroons » de LND. BTCPay Server lit le macaroon administrateur de LND, qui donne un contrôle total du nœud. Mettez d'abord LND à jour : avant \`0.21.1-beta:11\`, cette action laissait en place la clé racine des macaroons et ne révoquait donc rien en réalité.
+- **LND** — lancez l'action « Révoquer les macaroons » de LND. BTCPay Server lit le macaroon administrateur de LND, qui donne un contrôle total du nœud. Cela nécessite LND \`0.21.1-beta:11\` ou plus récent, désormais exigé comme dépendance : auparavant l'action s'appelait « Recréer les Macaroons » et supprimait seulement les fichiers de macaroons, laissant en place la clé racine qui les signe, sans donc rien révoquer.
 - **Core Lightning** — lancez l'action « Révoquer toutes les runes » de Core Lightning. BTCPay Server atteint CLN via son socket RPC d'administration : un serveur compromis a donc pu s'émettre une rune qui survit au correctif.
 
 Deux choses que cette mise à jour ne peut pas faire à votre place :
@@ -88,7 +88,7 @@ Deux choses que cette mise à jour ne peut pas faire à votre place :
         await sdk.action.createTask(
           effects,
           'lnd',
-          recreateMacaroons,
+          revokeMacaroons,
           'critical',
           {
             reason: i18n(


### PR DESCRIPTION
## Summary

2.4.2 patches an actively exploited vulnerability, but patching does not undo access an attacker already took. Everything BTCPay could reach on a pre-2.4.2 build should be treated as exposed, and for the Lightning backends that is actionable — so the `up` migration raises a critical task against whichever backend `btclightning` names:

| `btclightning` | Task target                    | Rotates                                        |
| -------------- | ------------------------------ | ---------------------------------------------- |
| LND            | `lnd` → `revoke-macaroons`     | The admin macaroon BTCPay reads off the mount  |
| CLN            | `c-lightning` → `revoke-runes` | Any rune mintable through the admin RPC socket |

Both tasks are gated on the backend being the configured one **and** its package being installed. The second guard is load-bearing: a critical task stops the source service and is cleared only when the *target* service runs the action, so raising one for an absent package would leave BTCPay unstartable short of a force-start.

Two exposures the migration deliberately does not try to cover, documented in the release notes and `instructions.md` instead:

- An install that pointed at a node and later switched away is indistinguishable from one that never did, so those users are told to rotate anyway.
- **A hot on-chain wallet generated inside BTCPay has keys that cannot be rotated at all** — those funds have to move.

Version bumped rather than folded into `2.4.2:0` so installs that already took `:0` from the alpha deploy still receive the prompt.

## Dependency floors

`dependencies.ts` floors `lnd` at `>=0.21.1-beta:11` and `c-lightning` at `>=26.6.6:9`, up from `:4` and `:1`. Neither action existed in usable form before those releases — LND's was named `recreate-macaroons` and only deleted the macaroon files, leaving the root key that signs them in place, so it revoked nothing ([lnd-startos#177](https://github.com/Start9Labs/lnd-startos/pull/177)); `revoke-runes` did not exist ([cln-startos#185](https://github.com/Start9Labs/cln-startos/pull/185)). Without the floors a user could be stopped by a critical task pointing at an action that does nothing.

**Merge order:** both sibling PRs must land, and reach the branches `package.json` pins, before this one builds.

## Test plan

- [ ] With LND selected, update from `2.4.2:0`; confirm BTCPay stops and shows a critical task pointing at LND's **Revoke Macaroons**
- [ ] Run that action; confirm the task clears, BTCPay starts, and Lightning invoicing still works with the new macaroon
- [ ] Repeat with CLN selected, against **Revoke All Runes**
- [ ] With **None/External** selected, confirm the update raises no task and BTCPay starts normally
- [ ] With LND selected but LND uninstalled, confirm no task is raised and BTCPay is not stranded
- [ ] With an LND older than `0.21.1-beta:11` installed, confirm the dependency floor surfaces rather than the task pointing at an ineffective action

🤖 Generated with [Claude Code](https://claude.com/claude-code)
