### PR TITLE
chore: bump NBXplorer to 2.6.11; 2.4.3-rc.4:0 → 2.4.3-rc.4:1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1600,7 +1600,7 @@
       }
     },
     "node_modules/cln-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#97c99c105de4f4570931110d03ae119882f1f40f",
+      "resolved": "git+ssh://git@github.com/Start9Labs/cln-startos.git#98c680ab7d7e6081d5735de3f4954c1e03f30691",
       "dependencies": {
         "@start9labs/start-sdk": "2.0.9",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",
@@ -1704,7 +1704,7 @@
       }
     },
     "node_modules/lnd-startos": {
-      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#5602827d75cca4210aa0f286aab63101ed4b4b99",
+      "resolved": "git+ssh://git@github.com/Start9Labs/lnd-startos.git#5049662023bc1860090ba6ac12a5379d3a390bfe",
       "dependencies": {
         "@start9labs/start-sdk": "2.0.9",
         "bitcoin-core-startos": "github:Start9Labs/bitcoin-core-startos#next/28.x",

--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -27,7 +27,7 @@ export const manifest = setupManifest({
     },
     nbx: {
       source: {
-        dockerTag: 'nicolasdorier/nbxplorer:2.6.10',
+        dockerTag: 'nicolasdorier/nbxplorer:2.6.11',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,33 +1,43 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '2.4.3-rc.4:0',
+  version: '2.4.3-rc.4:1',
   releaseNotes: {
-    en_US: `Security update — BTCPay Server 2.4.3-rc4.
+    en_US: `Updated NBXplorer to 2.6.11.
 
-This is a **pre-release build**. It is packaged from BTCPay Server's internal image channel ahead of upstream's public release: at packaging time, 2.4.3 had no published release, git tag, or changelog, so the specifics of the fix are not yet public.
+A maintenance release with no changes to NBXplorer itself: it rebuilds on the .NET 10.0.11 runtime, which carries this month's .NET security fixes, and on NBitcoin 10.0.9.
 
-Upstream's full release notes will appear at https://github.com/btcpayserver/btcpayserver/releases once 2.4.3 is published.`,
-    es_ES: `Actualización de seguridad — BTCPay Server 2.4.3-rc4.
+BTCPay Server stays on the 2.4.3-rc4 pre-release build shipped in the previous release.
 
-Esta es una **versión preliminar**. Se empaqueta desde el canal de imágenes interno de BTCPay Server antes de la publicación oficial: en el momento del empaquetado, 2.4.3 no tenía publicación, etiqueta de git ni registro de cambios, por lo que los detalles de la corrección aún no son públicos.
+Full changes: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
+    es_ES: `NBXplorer actualizado a 2.6.11.
 
-Las notas de versión completas aparecerán en https://github.com/btcpayserver/btcpayserver/releases cuando se publique 2.4.3.`,
-    de_DE: `Sicherheitsupdate — BTCPay Server 2.4.3-rc4.
+Una versión de mantenimiento sin cambios en NBXplorer: se recompila sobre el entorno de ejecución .NET 10.0.11, que incluye las correcciones de seguridad de .NET de este mes, y sobre NBitcoin 10.0.9.
 
-Dies ist ein **Vorabversions-Build**. Er wird aus dem internen Image-Kanal von BTCPay Server vor der öffentlichen Veröffentlichung paketiert: Zum Zeitpunkt der Paketierung hatte 2.4.3 weder eine veröffentlichte Release noch einen Git-Tag oder ein Changelog, sodass die Einzelheiten der Korrektur noch nicht öffentlich sind.
+BTCPay Server permanece en la versión preliminar 2.4.3-rc4 publicada en la versión anterior.
 
-Die vollständigen Release Notes erscheinen unter https://github.com/btcpayserver/btcpayserver/releases, sobald 2.4.3 veröffentlicht ist.`,
-    pl_PL: `Aktualizacja bezpieczeństwa — BTCPay Server 2.4.3-rc4.
+Cambios completos: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
+    de_DE: `NBXplorer auf 2.6.11 aktualisiert.
 
-To jest **wersja przedpremierowa**. Została spakowana z wewnętrznego kanału obrazów BTCPay Server przed publicznym wydaniem: w chwili pakowania 2.4.3 nie miała opublikowanego wydania, tagu git ani listy zmian, więc szczegóły poprawki nie są jeszcze publiczne.
+Eine Wartungsversion ohne Änderungen an NBXplorer selbst: Sie wird auf der .NET-Laufzeit 10.0.11 neu gebaut, die die .NET-Sicherheitskorrekturen dieses Monats enthält, sowie auf NBitcoin 10.0.9.
 
-Pełne informacje o wydaniu pojawią się na https://github.com/btcpayserver/btcpayserver/releases po opublikowaniu 2.4.3.`,
-    fr_FR: `Mise à jour de sécurité — BTCPay Server 2.4.3-rc4.
+BTCPay Server bleibt beim Vorabversions-Build 2.4.3-rc4 aus der vorherigen Veröffentlichung.
 
-Il s'agit d'une **version préliminaire**. Elle est empaquetée depuis le canal d'images interne de BTCPay Server avant la publication officielle : au moment de l'empaquetage, 2.4.3 n'avait ni publication, ni étiquette git, ni journal des modifications, de sorte que les détails du correctif ne sont pas encore publics.
+Vollständige Änderungen: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
+    pl_PL: `Zaktualizowano NBXplorer do 2.6.11.
 
-Les notes de version complètes paraîtront sur https://github.com/btcpayserver/btcpayserver/releases dès la publication de 2.4.3.`,
+Wydanie konserwacyjne bez zmian w samym NBXplorerze: zostało przebudowane na środowisku uruchomieniowym .NET 10.0.11, które zawiera tegomiesięczne poprawki bezpieczeństwa .NET, oraz na NBitcoin 10.0.9.
+
+BTCPay Server pozostaje na wersji przedpremierowej 2.4.3-rc4 opublikowanej w poprzednim wydaniu.
+
+Pełna lista zmian: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
+    fr_FR: `NBXplorer mis à jour vers 2.6.11.
+
+Une version de maintenance sans modification de NBXplorer lui-même : elle est reconstruite sur l'environnement d'exécution .NET 10.0.11, qui intègre les correctifs de sécurité .NET de ce mois-ci, ainsi que sur NBitcoin 10.0.9.
+
+BTCPay Server reste sur la version préliminaire 2.4.3-rc4 publiée précédemment.
+
+Changements complets : https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps the bundled **NBXplorer** image `2.6.10 → 2.6.11`, releasing as **`2.4.3-rc.4:1`**.

NBXplorer's other upstreams did not move, so nothing else is bumped:

| Image | Pin | Status |
| --- | --- | --- |
| `btcpayserver/btcpayserver-internal` | `2.4.3-rc4` | unchanged — no `rc5`, and 2.4.3 final is still unpublished (latest GitHub release is `v2.4.2`) |
| `nicolasdorier/nbxplorer` | `2.6.10` → **`2.6.11`** | bumped |
| `btcpayserver/postgres` | `18.4` | unchanged — newest published tag |
| `btcpayserver/shopify-app-deployer` | `1.10` | unchanged — newest published tag |

## What's in NBXplorer 2.6.11

A maintenance release with **no changes to NBXplorer's own code** — the entire diff is build/dependency version bumps ([`v2.6.10...v2.6.11`](https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11)):

- .NET runtime `10.0.10 → 10.0.11` — a [security release](https://github.com/dotnet/core/blob/main/release-notes/10.0/10.0.11/10.0.11.md) carrying 10 CVE fixes (RCE, EoP, information disclosure, DoS).
- .NET SDK `10.0.302 → 10.0.400` (build-time only).
- NBitcoin `10.0.8 → 10.0.9`.

Upstream publishes no GitHub Releases for NBXplorer, so the compare link above is the changelog.

## Artifact verification

`nicolasdorier/nbxplorer:2.6.11` is published and resolves for both packaged architectures (`linux/amd64`, `linux/arm64`, plus `linux/arm`).

## Version

`2.4.3-rc.4:0` is already published to the registry, so this takes the next free revision, `2.4.3-rc.4:1`. BTCPay Server itself is unchanged, so the upstream component of the version string does not move. Release notes lead with the NBXplorer bump and note that the build still ships the 2.4.3-rc4 pre-release, rather than re-announcing the security fix `:0` already announced.

## Also in this PR

- Refreshed the `*-startos` git dependency pins (`cln-startos`, `lnd-startos` moved). `start-sdk` is already at the latest published `2.0.9`; the lockfile still resolves exactly one SDK copy.
- No migration is needed — the image swap carries no state change.
- README / instructions carry no image tags, so neither needed an update.

## Test plan

- `npm run check` — green.
- Full `make` verification left to review, per the monitor cycle.
