### PR TITLE
chore: bump BTCPay Server to 2.4.3-rc5; 2.4.3-rc.4:1 → 2.4.3-rc.5:0

### DIFF
--- a/startos/manifest/index.ts
+++ b/startos/manifest/index.ts
@@ -21,7 +21,7 @@ export const manifest = setupManifest({
   images: {
     btcpay: {
       source: {
-        dockerTag: 'btcpayserver/btcpayserver-internal:2.4.3-rc4',
+        dockerTag: 'btcpayserver/btcpayserver-internal:2.4.3-rc5',
       },
       arch: ['x86_64', 'aarch64'],
     },

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,43 +1,48 @@
 import { VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '2.4.3-rc.4:1',
+  version: '2.4.3-rc.5:0',
   releaseNotes: {
-    en_US: `Updated NBXplorer to 2.6.11.
+    en_US: `Security update — BTCPay Server 2.4.3-rc5.
 
-A maintenance release with no changes to NBXplorer itself: it rebuilds on the .NET 10.0.11 runtime, which carries this month's .NET security fixes, and on NBitcoin 10.0.9.
+This is a **pre-release build**, packaged from BTCPay Server's internal image channel ahead of upstream's public release: 2.4.3 still has no published release, git tag, or changelog. The changes below were identified by comparing the published rc4 and rc5 images.
 
-BTCPay Server stays on the 2.4.3-rc4 pre-release build shipped in the previous release.
+- **Crowdfund** — an app's description is no longer rendered as raw HTML, closing a cross-site scripting vector.
+- **Shopify plugin** — BTCPay Server now refuses to load outdated versions of the Shopify plugin and keeps them disabled until they are updated. If you use the Shopify integration, update the Shopify plugin under **Server Settings → Plugins** after this update; the newer plugin fixes a refund webhook vulnerability.
 
-Full changes: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
-    es_ES: `NBXplorer actualizado a 2.6.11.
+Upstream's full release notes will appear at https://github.com/btcpayserver/btcpayserver/releases once 2.4.3 is published.`,
+    es_ES: `Actualización de seguridad — BTCPay Server 2.4.3-rc5.
 
-Una versión de mantenimiento sin cambios en NBXplorer: se recompila sobre el entorno de ejecución .NET 10.0.11, que incluye las correcciones de seguridad de .NET de este mes, y sobre NBitcoin 10.0.9.
+Esta es una **versión preliminar**, empaquetada desde el canal de imágenes interno de BTCPay Server antes de la publicación oficial: 2.4.3 aún no tiene publicación, etiqueta de git ni registro de cambios. Los cambios siguientes se identificaron comparando las imágenes publicadas de rc4 y rc5.
 
-BTCPay Server permanece en la versión preliminar 2.4.3-rc4 publicada en la versión anterior.
+- **Crowdfund** — la descripción de una aplicación ya no se representa como HTML sin procesar, lo que cierra un vector de scripting entre sitios.
+- **Complemento de Shopify** — BTCPay Server ahora se niega a cargar versiones desactualizadas del complemento de Shopify y las mantiene desactivadas hasta que se actualicen. Si utiliza la integración con Shopify, actualice el complemento de Shopify en **Configuración del servidor → Complementos** después de esta actualización; el complemento más reciente corrige una vulnerabilidad en el webhook de reembolsos.
 
-Cambios completos: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
-    de_DE: `NBXplorer auf 2.6.11 aktualisiert.
+Las notas de versión completas aparecerán en https://github.com/btcpayserver/btcpayserver/releases cuando se publique 2.4.3.`,
+    de_DE: `Sicherheitsupdate — BTCPay Server 2.4.3-rc5.
 
-Eine Wartungsversion ohne Änderungen an NBXplorer selbst: Sie wird auf der .NET-Laufzeit 10.0.11 neu gebaut, die die .NET-Sicherheitskorrekturen dieses Monats enthält, sowie auf NBitcoin 10.0.9.
+Dies ist ein **Vorabversions-Build**, paketiert aus dem internen Image-Kanal von BTCPay Server vor der öffentlichen Veröffentlichung: 2.4.3 hat weiterhin weder eine veröffentlichte Release noch einen Git-Tag oder ein Changelog. Die folgenden Änderungen wurden durch einen Vergleich der veröffentlichten rc4- und rc5-Images ermittelt.
 
-BTCPay Server bleibt beim Vorabversions-Build 2.4.3-rc4 aus der vorherigen Veröffentlichung.
+- **Crowdfund** — die Beschreibung einer App wird nicht mehr als rohes HTML gerendert, wodurch ein Cross-Site-Scripting-Vektor geschlossen wird.
+- **Shopify-Plugin** — BTCPay Server lädt veraltete Versionen des Shopify-Plugins nicht mehr und hält sie deaktiviert, bis sie aktualisiert werden. Wenn Sie die Shopify-Integration nutzen, aktualisieren Sie das Shopify-Plugin nach diesem Update unter **Servereinstellungen → Plugins**; das neuere Plugin behebt eine Schwachstelle im Rückerstattungs-Webhook.
 
-Vollständige Änderungen: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
-    pl_PL: `Zaktualizowano NBXplorer do 2.6.11.
+Die vollständigen Release Notes erscheinen unter https://github.com/btcpayserver/btcpayserver/releases, sobald 2.4.3 veröffentlicht ist.`,
+    pl_PL: `Aktualizacja bezpieczeństwa — BTCPay Server 2.4.3-rc5.
 
-Wydanie konserwacyjne bez zmian w samym NBXplorerze: zostało przebudowane na środowisku uruchomieniowym .NET 10.0.11, które zawiera tegomiesięczne poprawki bezpieczeństwa .NET, oraz na NBitcoin 10.0.9.
+To jest **wersja przedpremierowa**, spakowana z wewnętrznego kanału obrazów BTCPay Server przed publicznym wydaniem: wersja 2.4.3 nadal nie ma opublikowanego wydania, tagu git ani listy zmian. Poniższe zmiany ustalono, porównując opublikowane obrazy rc4 i rc5.
 
-BTCPay Server pozostaje na wersji przedpremierowej 2.4.3-rc4 opublikowanej w poprzednim wydaniu.
+- **Crowdfund** — opis aplikacji nie jest już renderowany jako surowy HTML, co zamyka wektor ataku cross-site scripting.
+- **Wtyczka Shopify** — BTCPay Server odmawia teraz ładowania nieaktualnych wersji wtyczki Shopify i pozostawia je wyłączone do czasu aktualizacji. Jeśli korzystasz z integracji z Shopify, po tej aktualizacji zaktualizuj wtyczkę Shopify w **Ustawienia serwera → Wtyczki**; nowsza wtyczka naprawia lukę w webhooku zwrotów.
 
-Pełna lista zmian: https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
-    fr_FR: `NBXplorer mis à jour vers 2.6.11.
+Pełne informacje o wydaniu pojawią się na https://github.com/btcpayserver/btcpayserver/releases po opublikowaniu wersji 2.4.3.`,
+    fr_FR: `Mise à jour de sécurité — BTCPay Server 2.4.3-rc5.
 
-Une version de maintenance sans modification de NBXplorer lui-même : elle est reconstruite sur l'environnement d'exécution .NET 10.0.11, qui intègre les correctifs de sécurité .NET de ce mois-ci, ainsi que sur NBitcoin 10.0.9.
+Il s'agit d'une **version préliminaire**, empaquetée depuis le canal d'images interne de BTCPay Server avant la publication officielle : 2.4.3 n'a toujours ni version publiée, ni étiquette git, ni journal des modifications. Les changements ci-dessous ont été identifiés en comparant les images rc4 et rc5 publiées.
 
-BTCPay Server reste sur la version préliminaire 2.4.3-rc4 publiée précédemment.
+- **Crowdfund** — la description d'une application n'est plus rendue en HTML brut, ce qui ferme un vecteur de script intersites.
+- **Extension Shopify** — BTCPay Server refuse désormais de charger les versions obsolètes de l'extension Shopify et les maintient désactivées jusqu'à leur mise à jour. Si vous utilisez l'intégration Shopify, mettez à jour l'extension Shopify dans **Paramètres du serveur → Extensions** après cette mise à jour ; la nouvelle extension corrige une vulnérabilité du webhook de remboursement.
 
-Changements complets : https://github.com/btcpayserver/NBXplorer/compare/v2.6.10...v2.6.11`,
+Les notes de version complètes apparaîtront sur https://github.com/btcpayserver/btcpayserver/releases une fois 2.4.3 publiée.`,
   },
   migrations: {},
 })


### PR DESCRIPTION
## Summary

Bumps BTCPay Server from the `2.4.3-rc4` prerelease build to `2.4.3-rc5`, published to the internal image channel on 2026-08-14. StartOS version `2.4.3-rc.4:1` → `2.4.3-rc.5:0`.

| Image | Before | After |
| --- | --- | --- |
| `btcpayserver/btcpayserver-internal` | `2.4.3-rc4` | **`2.4.3-rc5`** |
| `nicolasdorier/nbxplorer` | `2.6.11` | `2.6.11` (newest tag) |
| `btcpayserver/postgres` | `18.4` | `18.4` (newest multi-arch tag) |
| `btcpayserver/shopify-app-deployer` | `1.10` | `1.10` (newest tag) |

`@start9labs/start-sdk` is already at `2.0.9`, the latest on npm. The `*-startos` git deps were re-resolved from scratch and all five landed back on the same commits, so `package-lock.json` is unchanged; one start-sdk copy in the tree, no nested copies.

## What changed upstream

Upstream still publishes **no release, git tag, or changelog** for 2.4.3 — public `master` hasn't moved since v2.4.2 on 2026-08-07, and these RCs are staged embargoed on `btcpayserver-internal` (as UPDATING.md describes). So the change set below comes from diffing the two published images rather than from upstream notes.

rc4 → rc5 touches exactly one application file, `app/BTCPayServer.dll` (13,623,296 → 13,629,952 B). No plugin or dependency assembly changed, and no static asset content changed — the 1812 differing `staticwebassets.endpoints.json` entries differ only in their `Last-Modified` header, with every route and fingerprint identical. Two substantive changes are visible in the assembly's string heap:

1. **Crowdfund description is no longer rendered as raw HTML.**
   ```
   - <div class="overflow-hidden" v-html="srvModel.description" id="crowdfund-body-description">
   + <div class="overflow-hidden" id="crowdfund-body-description" v-pre>
   ```
   `v-html` → `v-pre` closes a cross-site scripting vector through a crowdfund app's description.

2. **The plugin loader gained a blocklist, and the only entry is the Shopify plugin.** New strings, in load order next to the existing `Skipping disabled plugin` / `Error when loading plugin` messages:
   ```
   Refusing to load the plugin
   , this version cannot be run. It has been disabled and will stay disabled
   until it is updated to a newer version.
   ...
   BTCPayServer.Plugins.ShopifyPlugin
   ```
   This lines up with upstream's timeline: `btcpayserver/btcpayserver-shopify-plugin` landed *"Fix refund webhook vulnerability and bump"* (5a532ae) on 2026-08-10 and bumped to 1.1.6 on 2026-08-14, ~2 h before the rc5 image was built. rc5 forces users off the vulnerable plugin versions.

The base image also refreshed krb5 to `1.20.1-6ubuntu2.8`, but that delta is only the PKINIT/Windows-Server-2025 fix — rc4 already carried `2.7` with CVE-2026-11850 and CVE-2026-4035x. Not worth mentioning to users, so it's not in the release notes.

## User-visible impact

This package doesn't install the Shopify plugin itself — it runs the deployer sidecar and users install the plugin into the mounted `Plugins/` volume. So anyone with the Shopify integration enabled and an outdated plugin will find it **auto-disabled** after this update until they update it under **Server Settings → Plugins**. That's called out explicitly in the release notes in all five locales.

## Artifact verification

`btcpayserver/btcpayserver-internal:2.4.3-rc5` resolves with both required arches:

- `amd64` — `sha256:62e2058da6c20686c26292ae8557aeb145cb15bff937e0f3b45cb7e8166e8064`
- `arm64` — `sha256:31d7da99c98f1863e75f77ad023cb553f6335816eeb0fe4973eb5214a6e0a0e2`

The other three pins were re-verified as still-newest and still-resolving. Registry currently publishes `2.4.3-rc.4:1` as best, so `2.4.3-rc.5:0` is free.

## Notes

- The pin stays on `btcpayserver-internal`. Per UPDATING.md and README, move it back to the public `btcpayserver/btcpayserver` repo once final 2.4.3 ships — latest public release is still v2.4.2.
- No migration: the upstream change is code-only, no state or config format change.
- No doc changes needed. README's prerelease-pin note (line 47) and the Shopify sections carry no version numbers and stay accurate.

## Test plan

- [x] `npm run check` green (`tsc --noEmit`)
- [x] `prettier --check` clean on both edited files
- [x] `2.4.3-rc.5:0` parses under `ValidateExVer` (the `rc.5` spelling — upstream's `rc5` would fail)
- [x] Both image arches confirmed present on Docker Hub
- [ ] `make` / install verification in review
